### PR TITLE
refactor : 컴포넌트 호출 방식 수정

### DIFF
--- a/src/frontend/core/component.js
+++ b/src/frontend/core/component.js
@@ -1,12 +1,15 @@
 export class Component {
-  constructor($target, props) {
-    this.$target = $target
+  dom
+  constructor(props) {
+    this.$template = document.createElement('template')
     this.props = props
     this.state = {}
     this.render()
   }
+
   render() {
-    this.$target.innerHTML = this.template()
+    this.$template.innerHTML = this.template()
+    this.dom = this.$template.content.cloneNode(true)
     this.setComponent()
     this.setEvent()
   }

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,4 +1,4 @@
 import './styles/style.scss'
 import App from './components/App.js'
 
-new App(document.querySelector('#app'))
+document.querySelector('#app').appendChild(new App().dom)


### PR DESCRIPTION
## 📑 개요

컴포넌트 호출 방식 수정

## 📎 관련 이슈

close #21

## 💬 작업 내용

자식 컴포넌트의 DOM을 부모컴포넌트에서 replace해주는 방식으로 수정했습니다.
`바꿀 Element.replaceWith(자식 컴포넌트 DOM)`

예시 코드 

```js

template() {
    const transactionDataList = getState(transactionListState)

    return /*html*/ `
            <div class="transaction-list-wrapper">
                ${transactionDataList.map((_) => `<div id="transaction-list"></div>`).join('')}
            </div>
      `
  }

  setComponent() {
    const transactionDataList = getState(transactionListState)
    const $replaceElementList = this.dom.querySelectorAll(`#transaction-list`)

    transactionDataList.forEach((data, idx) => {
      $replaceElementList[idx].replaceWith(
        new TransactionItem({
          category: data.category,
          title: data.title,
          payment: data.payment,
          price: data.price,
        }).dom,
      )
    })
  }
```

바꿀 div를 데이터 개수만큼 만든 후, `TransactionItem` 컴포넌트의 dom으로 바꿔치기(replace) 

## 🖼 스크린샷(추가사항)

<img width="675" alt="스크린샷 2022-07-21 오후 8 39 21" src="https://user-images.githubusercontent.com/60956392/180204962-c585a5da-dd9c-4a1c-ad46-2da476946b5e.png">


## 🚧 PR 특이 사항

민수님이 작업했던 헤더도 수정이 필요할 것 같습니다 ㅜ
