### PR TITLE
Fix/21/Component Architecture

### DIFF
--- a/src/frontend/components/App.js
+++ b/src/frontend/components/App.js
@@ -4,9 +4,6 @@ import ErrorPage from '../pages/ErrorPage.js'
 import { ROUTE } from '../utils/constants.js'
 
 export default class App extends Component {
-  constructor($target, props) {
-    super($target, props)
-  }
   route() {
     this.render()
   }
@@ -45,7 +42,7 @@ export default class App extends Component {
     }
 
     // URL에 따른 페이지 라우팅 처리
-    const $main = this.$target.querySelector('.main')
+    const $main = this.querySelector('.main')
     const { pathname } = location
     if (pathname === ROUTE.fileText) {
       // 가계부 페이지
@@ -62,3 +59,5 @@ export default class App extends Component {
     }
   }
 }
+
+customElements.define('app-root', App)

--- a/src/frontend/components/TransactionItem/TransactionItem.js
+++ b/src/frontend/components/TransactionItem/TransactionItem.js
@@ -17,3 +17,5 @@ export default class TransactionItem extends Component {
     `
   }
 }
+
+customElements.define('transaction-item', TransactionItem)

--- a/src/frontend/core/component.js
+++ b/src/frontend/core/component.js
@@ -1,15 +1,16 @@
-export class Component {
-  dom
+export class Component extends HTMLElement {
   constructor(props) {
-    this.$template = document.createElement('template')
+    super()
     this.props = props
-    this.state = {}
+    this.initState()
     this.render()
   }
 
+  // state 초기화
+  initState() {}
+
   render() {
-    this.$template.innerHTML = this.template()
-    this.dom = this.$template.content.cloneNode(true)
+    this.innerHTML = this.template()
     this.setComponent()
     this.setEvent()
   }

--- a/src/frontend/index.js
+++ b/src/frontend/index.js
@@ -1,4 +1,4 @@
 import './styles/style.scss'
 import App from './components/App.js'
 
-document.querySelector('#app').appendChild(new App().dom)
+document.querySelector('#app').appendChild(new App())


### PR DESCRIPTION
## 📑 개요

어제 수정한 방식은 자식 컴포넌트의 변화를 부모 컴포넌트가 감지할 수 없었습니다.

## 📎 관련 이슈

close #21

## 💬 작업 내용

어쨌든 우리는 자식컴포넌트의 요소 집합들을 부모 컴포넌트에 넣고 싶은 거니까, 자식 컴포넌트를 엘리먼트 그 자체로 만들면 어떨까 생각했습니다.
저 생각을 하니까 지난 주에 사용했던 웹컴포넌트가 떠올랐습니다.
컴포넌트 자체를 엘리먼트로 만들었더니 자식 컴포넌트가 리렌더링이 되면 부모 컴포넌트가 바로 알 수 있었습니다.

그리고 기존에 constructor 에서 state를 초기화 해주었는데, 이렇게 하면 렌더링이 된 후에 state가 초기화가 되기 때문에, 원하는 방식대로 동작하지 않았습니다.

그래서 `initState` 라는 메서드를 만들어서 렌더링 되기 전에 초기화가 될 수 있도록 해주었습니다.



## 🚧 PR 특이 사항

구조를 잡기까지 너무 많은 시간이 걸렸네요...
속도를 올려야겠습니다 ㅜ