### PR TITLE
Feat/54/doughnut-server-api

### DIFF
--- a/src/frontend/api/transactionHistory.js
+++ b/src/frontend/api/transactionHistory.js
@@ -6,4 +6,10 @@ const getTransactionHistoryList = async (year, month) => {
   return data ?? []
 }
 
-export { getTransactionHistoryList }
+const getExpenseTransactionHistoryList = async (year, month) => {
+  const { data } = await fetcher.get(`/transaction/category?year=${year}&month=${month}`)
+
+  return data ?? []
+}
+
+export { getTransactionHistoryList, getExpenseTransactionHistoryList }

--- a/src/frontend/components/App.js
+++ b/src/frontend/components/App.js
@@ -7,8 +7,12 @@ import ChartPage from '../pages/ChartPage/ChartPage.js'
 import ErrorPage from '../pages/ErrorPage.js'
 import { transactionListState } from '../stores/transactionStore.js'
 import { dateState } from '../stores/dateStore.js'
-import { getTransactionHistoryList } from '../api/transactionHistory.js'
+import {
+  getTransactionHistoryList,
+  getExpenseTransactionHistoryList,
+} from '../api/transactionHistory.js'
 import { getState, setState, subscribe } from '../core/observer.js'
+import { expenseTransactionListState } from '../stores/chartStore.js'
 
 export default class App extends Component {
   constructor() {
@@ -66,10 +70,18 @@ export default class App extends Component {
   }
 
   async componentDidMount() {
+    const { pathname } = location
     const { year, month } = getState(dateState)
-    const setTransactionListState = setState(transactionListState)
-    const transactionListData = await getTransactionHistoryList(year, month)
-    setTransactionListState(transactionListData)
+
+    if (pathname === ROUTE['file-text'] || pathname === ROUTE.calendar) {
+      const setTransactionListState = setState(transactionListState)
+      const transactionListData = await getTransactionHistoryList(year, month)
+      setTransactionListState(transactionListData)
+    } else if (pathname === ROUTE.chart) {
+      const setExpenseTransactionListState = setState(expenseTransactionListState)
+      const expenseTransactionListData = await getExpenseTransactionHistoryList(year, month)
+      setExpenseTransactionListState(expenseTransactionListData)
+    }
   }
 }
 

--- a/src/frontend/components/DoughnutChart/DoughnutChart.js
+++ b/src/frontend/components/DoughnutChart/DoughnutChart.js
@@ -1,49 +1,69 @@
 import { Component } from '../../core/component.js'
+import { getState, setState, subscribe } from '../../core/observer.js'
+import { expenseTransactionListState, selectedCategoryState } from '../../stores/chartStore.js'
 import { CATEGORY } from '../../utils/constants.js'
 import { priceToString } from '../../utils/stringUtil.js'
 import './doughnutChart.scss'
 
-const dummy = [
-  { category: 'food', price: '780000' },
-  { category: 'traffic', price: '830000' },
-  { category: 'culture', price: '760000' },
-  { category: 'undefined', price: '1020000' },
-  { category: 'life', price: '850000' },
-  { category: 'health', price: '780000' },
-]
-
 export default class DoughnutChart extends Component {
+  constructor() {
+    super()
+
+    this.setCategory = setState(selectedCategoryState)
+    subscribe(expenseTransactionListState, this.render.bind(this))
+  }
   template() {
-    const totalExpense = this.getTotalExpense(dummy)
+    const expenseTransactionHistoryList = getState(expenseTransactionListState)
+    const totalExpense = this.getTotalExpense(expenseTransactionHistoryList)
+
+    if (!expenseTransactionHistoryList.length) {
+      return /*html*/ `
+        <div class="doughnut-board">지출 내역이 존재하지 않습니다.</div>
+      `
+    }
 
     return /*html*/ `
       <div class="doughnut-board">
-      <svg width="300px" height="300px" viewBox="0 0 100 100" class="doughnut">
-      </svg>
+      ${this.printChart()}
         <div class="doughnut-price-wrapper">
           <p class="doughnut-price-total">이번 달 지출 금액 ${priceToString(totalExpense)}</p>
-          ${dummy
-            .map(
-              (categoryExpense) => `<div class="price-category-wrapper">
-          <div class="category-chip ${categoryExpense.category}">${
-                CATEGORY[categoryExpense.category]
-              }</div>
-          <p class="category-percentage">${this.getExpenseRatio(
-            categoryExpense.price,
-            totalExpense,
-          )}%</p>
-          <p class="category-price">${priceToString(categoryExpense.price)}</p>
-        </div>`,
-            )
-            .join('')}
-          
+          <div class="doughnut-category-list">
+            ${expenseTransactionHistoryList
+              .map(
+                (categoryExpense) => `<div class="price-category-wrapper" data-category="${
+                  categoryExpense.category
+                }">
+            <div class="category-chip ${categoryExpense.category}">${
+                  CATEGORY[categoryExpense.category]
+                }</div>
+            <p class="category-percentage">${this.getExpenseRatio(
+              categoryExpense.price,
+              totalExpense,
+            )}%</p>
+            <p class="category-price">${priceToString(categoryExpense.price)}</p>
+          </div>`,
+              )
+              .join('')}
+          </div>
         </div>
       </div>
     `
   }
 
-  setComponent() {
-    this.printChart()
+  setEvent() {
+    const expenseTransactionHistoryList = getState(expenseTransactionListState)
+    if (!expenseTransactionHistoryList.length) return
+
+    const $doughnutCategoryList = this.querySelector('.doughnut-category-list')
+
+    $doughnutCategoryList.addEventListener('click', this.handleClickExpenseCategory.bind(this))
+  }
+
+  handleClickExpenseCategory(e) {
+    const $categoryWrapper = e.target.closest('.price-category-wrapper')
+    const { category } = $categoryWrapper.dataset
+
+    this.setCategory(category)
   }
 
   getTotalExpense(data) {
@@ -56,14 +76,15 @@ export default class DoughnutChart extends Component {
   }
 
   printChart() {
+    const expenseTransactionHistoryList = getState(expenseTransactionListState)
     const radius = 40 // 차트의 반지름
     const diameter = 2 * Math.PI * radius // 차트의 둘레
 
-    const categories = dummy.map(({ category }) => category)
-    const prices = dummy.map(({ price }) => Number(price))
+    const categories = expenseTransactionHistoryList.map(({ category }) => category)
+    const prices = expenseTransactionHistoryList.map(({ price }) => Number(price))
 
     // 전체 데이터셋의 총 합
-    const totalSum = this.getTotalExpense(dummy)
+    const totalSum = this.getTotalExpense(expenseTransactionHistoryList)
 
     // 데이터셋의 누적 값
     const acc = prices.reduce(
@@ -73,8 +94,6 @@ export default class DoughnutChart extends Component {
       },
       [0],
     )
-
-    const $svg = this.querySelector('.doughnut')
 
     const $circles = prices.reduce((circles, price, idx) => {
       // 비율
@@ -90,7 +109,11 @@ export default class DoughnutChart extends Component {
       return (circles += $circle)
     }, '')
 
-    $svg.innerHTML = $circles
+    return `
+      <svg width="300px" height="300px" viewBox="0 0 100 100" class="doughnut">
+        ${$circles}
+      </svg>
+    `
   }
 }
 

--- a/src/frontend/components/DoughnutChart/doughnutChart.scss
+++ b/src/frontend/components/DoughnutChart/doughnutChart.scss
@@ -7,6 +7,7 @@
   width: 848px;
 
   display: flex;
+  justify-content: center;
   align-items: center;
   gap: 90px;
 
@@ -65,4 +66,8 @@
 .category-price {
   flex: 1;
   text-align: right;
+}
+
+svg.doughnut {
+  transform: rotate(-90deg);
 }

--- a/src/frontend/pages/ChartPage/ChartPage.js
+++ b/src/frontend/pages/ChartPage/ChartPage.js
@@ -1,22 +1,48 @@
 import DoughnutChart from '../../components/DoughnutChart/DoughnutChart.js'
 import { Component } from '../../core/component.js'
+import { getState, subscribe } from '../../core/observer.js'
+import {
+  selectedCategoryState,
+  selectedCategoryState,
+  selectedCategoryTransactionListState,
+} from '../../stores/chartStore.js'
 import './chartPage.scss'
 
 export default class ChartPage extends Component {
+  constructor() {
+    super()
+
+    subscribe(selectedCategoryState, this.render.bind(this))
+    subscribe(selectedCategoryTransactionListState, this.render.bind(this))
+  }
   template() {
     return /*html*/ `
     <div class="chart-page-container">
        <div class="chart-page-wrapper">
-        <div id="donut-chart-replace"></div>
+        <div id="doughnut-chart-replace"></div>
+
+
+        <div class="category-transaction-list">
+        </div>
        </div>
     </div>
     `
   }
 
   setComponent() {
-    const $donutChartReplace = this.querySelector('#donut-chart-replace')
+    const $doughnutChartReplace = this.querySelector('#doughnut-chart-replace')
+    $doughnutChartReplace.replaceWith(new DoughnutChart())
 
-    $donutChartReplace.replaceWith(new DoughnutChart())
+    const selectedCategoryState = getState(selectedCategoryState)
+    if (selectedCategoryState) {
+      const $categoryTransactionList = this.querySelector('.category-transaction-list')
+
+      $categoryTransactionList.appendChild()
+    }
+  }
+
+  componentDidMount() {
+    const selectedCategoryState = getState(selectedCategoryState)
   }
 }
 customElements.define('chart-container', ChartPage)

--- a/src/frontend/stores/chartStore.js
+++ b/src/frontend/stores/chartStore.js
@@ -1,0 +1,16 @@
+import { initState } from '../core/observer.js'
+
+export const expenseTransactionListState = initState({
+  key: 'expenseTransactionListState',
+  defaultValue: [],
+})
+
+export const selectedCategoryState = initState({
+  key: 'chart/selectedCategoryState',
+  defaultValue: '',
+})
+
+export const selectedCategoryTransactionListState = initState({
+  key: 'chart/selectedCategoryTransactionListState',
+  defaultValue: [],
+})


### PR DESCRIPTION
## 📑 개요

도넛 차트 서버 연동

## 📎 관련 이슈

close #54 

## 💬 작업 내용

도넛 차트 데이터 불러오기 

도넛 차트 -90도 회전

지출 내역 없을 때, 지출 내역 없다는 안내 띄우기


## 🖼 스크린샷(추가사항)

<img width="1180" alt="스크린샷 2022-07-26 오후 4 17 11" src="https://user-images.githubusercontent.com/60956392/180946741-685a87ea-d9ea-4403-b0ef-f1dce4458cae.png">

<img width="985" alt="스크린샷 2022-07-26 오후 4 17 17" src="https://user-images.githubusercontent.com/60956392/180961842-64288ccd-633f-4439-8daf-e2f1c80133ad.png">


## 🚧 PR 특이 사항

이제 카테고리 클릭 시, 라인 차트 띄우기 및 거래내역 불러오는 로직 구현해야합니다.
