### PR TITLE
Feat/47/category-expense-list-api

### DIFF
--- a/src/backend/controllers/transactionHistory.js
+++ b/src/backend/controllers/transactionHistory.js
@@ -12,7 +12,7 @@ const getCategoryExpenseDetailTransactionList = async (req, res) => {
   const { year, month, category } = req.query
 
   const data = await TransactionService.getCategoryExpenseTransactionList(year, month, category)
-  
+
   res.status(200).send({ data })
 }
 
@@ -24,4 +24,8 @@ const getExpenseTransactionHistory = async (req, res) => {
   res.status(200).send({ data })
 }
 
-export { getTransactionHistory, getExpenseTransactionHistory, getCategoryExpenseDetailTransactionList }
+export {
+  getTransactionHistory,
+  getExpenseTransactionHistory,
+  getCategoryExpenseDetailTransactionList,
+}

--- a/src/backend/controllers/transactionHistory.js
+++ b/src/backend/controllers/transactionHistory.js
@@ -8,4 +8,12 @@ const getTransactionHistory = async (req, res) => {
   res.status(200).send({ data })
 }
 
-export { getTransactionHistory }
+const getCategoryExpenseDetailTransactionList = async (req, res) => {
+  const { year, month, category } = req.query
+
+  const data = await TransactionService.getCategoryExpenseTransactionList(year, month, category)
+
+  res.status(200).send({ data })
+}
+
+export { getTransactionHistory, getCategoryExpenseDetailTransactionList }

--- a/src/backend/routes/transactionHistory.js
+++ b/src/backend/routes/transactionHistory.js
@@ -1,8 +1,13 @@
 import express from 'express'
-import { getTransactionHistory } from '../controllers/transactionHistory.js'
+import {
+  getCategoryExpenseDetailTransactionList,
+  getTransactionHistory,
+} from '../controllers/transactionHistory.js'
 
 const transactionRouter = express.Router()
 
 transactionRouter.get('/', getTransactionHistory)
+
+transactionRouter.get('/category/detail', getCategoryExpenseDetailTransactionList)
 
 export { transactionRouter }

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -1,3 +1,5 @@
+import { Op } from 'zihorm'
+import zihorm from '../config/db.js'
 import TransactionHistory from '../models/transactionHistory.js'
 
 const TransactionService = {
@@ -16,6 +18,55 @@ const TransactionService = {
       where: {
         'YEAR(payment_date)': year,
         'MONTH(payment_date)': month,
+      },
+    })
+
+    // 삭제된 결제수단이면 공백처리
+    response.forEach((transactionData) => {
+      if (!transactionData.is_deleted) return
+
+      transactionData.payment = ''
+      delete transactionData.is_deleted
+    })
+
+    return response
+  },
+
+  // 도넛차트를 위한 get 요청, 매달 카테고리별 지출 내역
+  getExpenseTransactionList: async (year, month) => {
+    const response = await TransactionHistory.findAll({
+      attributes: ['category', 'ABS(SUM(price)) as price'],
+      where: {
+        price: {
+          [Op.lt]: 0,
+        },
+        'YEAR(payment_date)': year,
+        'MONTH(payment_date)': month,
+      },
+      order: ['price', 'DESC'],
+      groupBy: 'category',
+    })
+
+    return response
+  },
+
+  // 카테고리별 상세 지출 내역 가져오기 위한 get 요청
+  getCategoryExpenseTransactionList: async (year, month, category) => {
+    const response = await TransactionHistory.findAll({
+      attributes: [
+        'transaction_history.id',
+        'payment_date',
+        'category',
+        'title',
+        'price',
+        'name as payment',
+        'is_deleted',
+      ],
+      include: { fk: 'payment_id', joinPk: 'id', model: 'payment' },
+      where: {
+        'YEAR(payment_date)': year,
+        'MONTH(payment_date)': month,
+        category,
       },
     })
 

--- a/src/frontend/pages/ChartPage/ChartPage.js
+++ b/src/frontend/pages/ChartPage/ChartPage.js
@@ -3,7 +3,6 @@ import { Component } from '../../core/component.js'
 import { getState, subscribe } from '../../core/observer.js'
 import {
   selectedCategoryState,
-  selectedCategoryState,
   selectedCategoryTransactionListState,
 } from '../../stores/chartStore.js'
 import './chartPage.scss'

--- a/src/frontend/pages/ChartPage/ChartPage.js
+++ b/src/frontend/pages/ChartPage/ChartPage.js
@@ -31,17 +31,6 @@ export default class ChartPage extends Component {
   setComponent() {
     const $doughnutChartReplace = this.querySelector('#doughnut-chart-replace')
     $doughnutChartReplace.replaceWith(new DoughnutChart())
-
-    const selectedCategoryState = getState(selectedCategoryState)
-    if (selectedCategoryState) {
-      const $categoryTransactionList = this.querySelector('.category-transaction-list')
-
-      $categoryTransactionList.appendChild()
-    }
-  }
-
-  componentDidMount() {
-    const selectedCategoryState = getState(selectedCategoryState)
   }
 }
 customElements.define('chart-container', ChartPage)


### PR DESCRIPTION
## 📑 개요

카테고리별 지출 거래 내역 불러오기 API 구현

## 📎 관련 이슈

close #47 

## 💬 작업 내용

카테고리별 지출 거래 내역 불러오기 API 서비스 구현
카테고리별 지출 거래 내역 불러오기 API 컨트롤러 구현
카테고리별 지출 거래 내역 불러오기 API 라우트 연결

## 🚧 PR 특이 사항
