### PR TITLE
Feat/29/category-data-six-month

### DIFF
--- a/src/backend/controllers/transactionHistory.js
+++ b/src/backend/controllers/transactionHistory.js
@@ -16,4 +16,20 @@ const getExpenseTransactionHistory = async (req, res) => {
   res.status(200).send({ data })
 }
 
-export { getTransactionHistory, getExpenseTransactionHistory }
+const getSixMonthCategoryExpenseTransactionHistory = async (req, res) => {
+  const { year, month, category } = req.query
+
+  const data = await TransactionService.getSixMonthCategoryExpenseTransactionList(
+    year,
+    month,
+    category,
+  )
+
+  res.status(200).send({ data })
+}
+
+export {
+  getTransactionHistory,
+  getExpenseTransactionHistory,
+  getSixMonthCategoryExpenseTransactionHistory,
+}

--- a/src/backend/routes/transactionHistory.js
+++ b/src/backend/routes/transactionHistory.js
@@ -2,11 +2,14 @@ import express from 'express'
 import {
   getExpenseTransactionHistory,
   getTransactionHistory,
+  getSixMonthCategoryExpenseTransactionHistory,
 } from '../controllers/transactionHistory.js'
 
 const transactionRouter = express.Router()
 
 transactionRouter.get('/', getTransactionHistory)
 transactionRouter.get('/category', getExpenseTransactionHistory)
+
+transactionRouter.get('/category/six-month', getSixMonthCategoryExpenseTransactionHistory)
 
 export { transactionRouter }

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -101,7 +101,7 @@ const TransactionService = {
     )
 
     const sixMonthData = getSixMonthObject(year, month)
-    console.log(sixMonthData)
+
     sixMonthExpenseData.forEach((data) => {
       const { year, month, price } = data
       sixMonthData[`${year}-${fillZero(month)}`] = price

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -82,7 +82,7 @@ const TransactionService = {
     return response
   },
 
-  // 라인차트를 위한 get 요청, 6개월 데이터
+  // 라인차트를 위한 get 요청, 최근 6개월 데이터
   getSixMonthCategoryExpenseTransactionList: async (year, month, category) => {
     const [startYear, startMonth] = getBeforeSixMonthDate(year, month)
 

--- a/src/backend/utils/dateUtil.js
+++ b/src/backend/utils/dateUtil.js
@@ -3,14 +3,9 @@ const fillZero = (number) => {
 }
 
 const getSixMonthObject = (year, month) => {
-  if (month >= 6) {
-    return new Array(6).fill(null).reduce((sixMonthObject, cur, idx) => {
-      sixMonthObject[`${year}-${fillZero(month - 5 + idx)}`] = 0
-      return sixMonthObject
-    }, {})
-  } else {
+  if (month <= 6) {
     const sixMonthObject = {}
-    const lastYearCount = 6 - month
+    const lastYearCount = 7 - month
 
     new Array(lastYearCount).fill(null).forEach((_, idx) => {
       sixMonthObject[`${year - 1}-${fillZero(12 - lastYearCount + idx)}`] = 0
@@ -20,13 +15,18 @@ const getSixMonthObject = (year, month) => {
       sixMonthObject[`${year}-${fillZero(idx + 1)}`] = 0
     })
     return sixMonthObject
+  } else {
+    return new Array(7).fill(null).reduce((sixMonthObject, cur, idx) => {
+      sixMonthObject[`${year}-${fillZero(month - 6 + idx)}`] = 0
+      return sixMonthObject
+    }, {})
   }
 }
 
 const getBeforeSixMonthDate = (year, month) => {
-  const ADD_MONTH = 7
-  const MINUS_MONTH = 5
-  if (month <= 5) {
+  const ADD_MONTH = 6
+  const MINUS_MONTH = 6
+  if (month <= 6) {
     return [year - 1, month + ADD_MONTH]
   } else {
     return [year, month - MINUS_MONTH]

--- a/src/backend/utils/dateUtil.js
+++ b/src/backend/utils/dateUtil.js
@@ -1,0 +1,36 @@
+const fillZero = (number) => {
+  return number < 10 ? `0${number}` : number
+}
+
+const getSixMonthObject = (year, month) => {
+  if (month >= 6) {
+    return new Array(6).fill(null).reduce((sixMonthObject, cur, idx) => {
+      sixMonthObject[`${year}-${fillZero(month - 5 + idx)}`] = 0
+      return sixMonthObject
+    }, {})
+  } else {
+    const sixMonthObject = {}
+    const lastYearCount = 6 - month
+
+    new Array(lastYearCount).fill(null).forEach((_, idx) => {
+      sixMonthObject[`${year - 1}-${fillZero(12 - lastYearCount + idx)}`] = 0
+    })
+
+    new Array(month).fill(null).forEach((_, idx) => {
+      sixMonthObject[`${year}-${fillZero(idx + 1)}`] = 0
+    })
+    return sixMonthObject
+  }
+}
+
+const getBeforeSixMonthDate = (year, month) => {
+  const ADD_MONTH = 7
+  const MINUS_MONTH = 5
+  if (month <= 5) {
+    return [year - 1, month + ADD_MONTH]
+  } else {
+    return [year, month - MINUS_MONTH]
+  }
+}
+
+export { getSixMonthObject, getBeforeSixMonthDate, fillZero }


### PR DESCRIPTION
## 📑 개요

## 📎 관련 이슈

close #29

## 💬 작업 내용

```js
getSixMonthObject(year,month)
```
위 함수를 이용해서 6개월 전, 5개월 전, 4개월 전, 3개월 전, 2개월 전, 1개월 전, 현재 달에 대한 객체를 만듭니다.

```js
{
    "2021-01": 0,
    "2021-02": 0,
    "2021-03": 0,
    "2021-04": 0,
    "2021-05": 0,
    "2021-06":  0,
    "2021-07": 0
}
```

그리고 DB에서 데이터를 불러와서 해당 년,월에 맞게 값을 넣어줍니다.

이렇게 한 이유는 쿼리로 Group by 했을 때, 해당 날짜에 데이터가 없으면 ROW가 안생겨서 DB가 아닌 백엔드 쪽에서 처리해주는 방식을 선택했습니다.

## 🚧 PR 특이 사항

원하는 정보를 가공하기 위해서 어거지로 데이터를 넣은 느낌이 드는 것 같습니다.. 시간이 남는다면 리팩토링을 하겠습니다.