### PR TITLE
Feat/62/category transaction list

### DIFF
--- a/src/frontend/components/App.js
+++ b/src/frontend/components/App.js
@@ -73,11 +73,11 @@ export default class App extends Component {
     const { pathname } = location
     const { year, month } = getState(dateState)
 
-    if (pathname === ROUTE['file-text'] || pathname === ROUTE.calendar) {
-      const setTransactionListState = setState(transactionListState)
-      const transactionListData = await getTransactionHistoryList(year, month)
-      setTransactionListState(transactionListData)
-    } else if (pathname === ROUTE.chart) {
+    const setTransactionListState = setState(transactionListState)
+    const transactionListData = await getTransactionHistoryList(year, month)
+    setTransactionListState(transactionListData)
+
+    if (pathname === ROUTE.chart) {
       const setExpenseTransactionListState = setState(expenseTransactionListState)
       const expenseTransactionListData = await getExpenseTransactionHistoryList(year, month)
       setExpenseTransactionListState(expenseTransactionListData)

--- a/src/frontend/components/DateTransactionList/DateTransactionList.js
+++ b/src/frontend/components/DateTransactionList/DateTransactionList.js
@@ -8,7 +8,7 @@ import './dateTransactionList.scss'
 
 export default class DateTransactionList extends Component {
   template() {
-    const { transactionList } = this.props
+    const { transactionList, showTotal } = this.props
 
     const [mm, dd, day] = this.convertDate(transactionList[0].payment_date)
     const [income, expense] = calculateTransaction(transactionList)
@@ -20,9 +20,14 @@ export default class DateTransactionList extends Component {
                     <span class="date-transaction-header-date">${mm}월 ${dd}일<span>
                     <span class="date-transaction-header-day">${day}<span>
                 </div>
-                <p class="date-transaction-header-summary">
+                ${
+                  showTotal
+                    ? `<p class="date-transaction-header-summary">
                 ${income ? `수입 ${priceToString(income)}` : ''}
-                ${expense ? `지출 ${priceToString(expense)}` : ''}</p>
+                ${expense ? `지출 ${priceToString(expense)}` : ''}
+                </p>`
+                    : ''
+                }
             </div>
             <div class="date-transaction-list">
             </div>

--- a/src/frontend/components/Header/Header.js
+++ b/src/frontend/components/Header/Header.js
@@ -8,12 +8,14 @@ import IconRightArrow from '../../assets/right-arrow.svg'
 import { getState, subscribe, setState } from '../../core/observer.js'
 import { dateState } from '../../stores/dateStore.js'
 import './header.scss'
+import { selectedCategoryState } from '../../stores/chartStore.js'
 
 export default class Header extends Component {
   constructor(props) {
     super(props)
     subscribe(dateState, this.render.bind(this))
     this.setDate = setState(dateState)
+    this.setSelectedCategory = setState(selectedCategoryState)
   }
 
   template() {
@@ -97,6 +99,7 @@ export default class Header extends Component {
     const { nextYear, nextMonth } = this.makeCalendar(year, month, className)
 
     this.setDate({ year: nextYear, month: nextMonth })
+    this.setSelectedCategory('')
   }
 
   makeCalendar(year, month, className) {

--- a/src/frontend/components/TransactionList/TransactionList.js
+++ b/src/frontend/components/TransactionList/TransactionList.js
@@ -6,7 +6,6 @@ import DateTransactionList from '../DateTransactionList/DateTransactionList.js'
 import './transactionList.scss'
 import IconCheckboxDefault from '../../assets/checkbox-default.svg'
 import IconCheckboxActive from '../../assets/checkbox-active.svg'
-import { dateState } from '../../stores/dateStore.js'
 
 export default class TransactionList extends Component {
   constructor(props) {

--- a/src/frontend/pages/ChartPage/chartPage.scss
+++ b/src/frontend/pages/ChartPage/chartPage.scss
@@ -14,3 +14,8 @@
   flex-direction: column;
   align-items: center;
 }
+
+.category-transaction-list {
+  max-width: 848px;
+  width: 100%;
+}

--- a/src/frontend/stores/chartStore.js
+++ b/src/frontend/stores/chartStore.js
@@ -9,8 +9,3 @@ export const selectedCategoryState = initState({
   key: 'chart/selectedCategoryState',
   defaultValue: '',
 })
-
-export const selectedCategoryTransactionListState = initState({
-  key: 'chart/selectedCategoryTransactionListState',
-  defaultValue: [],
-})


### PR DESCRIPTION
## 📑 개요

차트페이지 카테고리 클릭 시 거래 내역 띄우기

## 📎 관련 이슈

close #62 

## 💬 작업 내용

새로운 API를 만들어서 작업하려고 했는데,
기존에 만들었던 해당 월 전체 거래내역 불러와서 category로 filter 해주는 로직으로 변경했습니다.

카테고리를 누르면 거래 내역이 뜹니다.
`DateTransactionList` 컴포넌트에서 수입,지출 총합을 띄울 지 props로 분기처리 추가했습니다.
날짜 수정 시, 선택 카테고리 초기화 시켰습니다.


## 🖼 스크린샷(추가사항)

<img width="939" alt="스크린샷 2022-07-26 오후 10 07 40" src="https://user-images.githubusercontent.com/60956392/181013756-5d874745-ad45-477d-a941-d7e6a8f99653.png">
<img width="925" alt="스크린샷 2022-07-26 오후 10 07 32" src="https://user-images.githubusercontent.com/60956392/181013765-75e2d216-ae61-48ab-8d34-58f468473f7e.png">


## 🚧 PR 특이 사항

기존에 만들었던 카테고리에 따른 거래내역 불러오는 API 삭제하겠습니다.
