### PR TITLE
Feat/36/line chart

### DIFF
--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -101,11 +101,11 @@ const TransactionService = {
       `,
     )
 
-    const monthsData = getMonthsObject(year, month)
+    const monthsData = getMonthsObject(Number(year), Number(month))
 
     sixMonthExpenseData.forEach((data) => {
       const { year, month, price } = data
-      monthsData[`${year}-${fillZero(month)}`] = price
+      monthsData[`${year}-${Number(month)}`] = price
     })
 
     return monthsData

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -1,7 +1,7 @@
 import { Op } from 'zihorm'
 import zihorm from '../config/db.js'
 import TransactionHistory from '../models/transactionHistory.js'
-import { getBeforeSixMonthDate, fillZero, getSixMonthObject } from '../utils/dateUtil.js'
+import { getBeforeSixMonthDate, fillZero, getMonthsObject } from '../utils/dateUtil.js'
 
 const TransactionService = {
   // 메인, 달력 페이지를 위한 get 요청, 수입,지출 거래 내역
@@ -101,14 +101,14 @@ const TransactionService = {
       `,
     )
 
-    const sixMonthData = getSixMonthObject(year, month)
+    const monthsData = getMonthsObject(year, month)
 
     sixMonthExpenseData.forEach((data) => {
       const { year, month, price } = data
-      sixMonthData[`${year}-${fillZero(month)}`] = price
+      monthsData[`${year}-${fillZero(month)}`] = price
     })
 
-    return sixMonthData
+    return monthsData
   },
 }
 

--- a/src/backend/utils/dateUtil.js
+++ b/src/backend/utils/dateUtil.js
@@ -2,23 +2,24 @@ const fillZero = (number) => {
   return number < 10 ? `0${number}` : number
 }
 
-const getSixMonthObject = (year, month) => {
+const getMonthsObject = (year, month) => {
   if (month <= 6) {
-    const sixMonthObject = {}
+    const monthsObject = {}
     const lastYearCount = 7 - month
 
     new Array(lastYearCount).fill(null).forEach((_, idx) => {
-      sixMonthObject[`${year - 1}-${fillZero(12 - lastYearCount + idx)}`] = 0
+      monthsObject[`${year - 1}-${fillZero(12 - lastYearCount + idx + 1)}`] = 0
     })
 
-    new Array(month).fill(null).forEach((_, idx) => {
-      sixMonthObject[`${year}-${fillZero(idx + 1)}`] = 0
+    new Array(12 - lastYearCount).fill(null).forEach((_, idx) => {
+      monthsObject[`${year}-${fillZero(idx + 1)}`] = 0
     })
-    return sixMonthObject
+
+    return monthsObject
   } else {
-    return new Array(7).fill(null).reduce((sixMonthObject, cur, idx) => {
-      sixMonthObject[`${year}-${fillZero(month - 6 + idx)}`] = 0
-      return sixMonthObject
+    return new Array(12).fill(null).reduce((monthsObject, cur, idx) => {
+      monthsObject[`${year}-${fillZero(month - 6 + idx)}`] = 0
+      return monthsObject
     }, {})
   }
 }
@@ -33,4 +34,4 @@ const getBeforeSixMonthDate = (year, month) => {
   }
 }
 
-export { getSixMonthObject, getBeforeSixMonthDate, fillZero }
+export { getMonthsObject, getBeforeSixMonthDate, fillZero }

--- a/src/backend/utils/dateUtil.js
+++ b/src/backend/utils/dateUtil.js
@@ -3,22 +3,44 @@ const fillZero = (number) => {
 }
 
 const getMonthsObject = (year, month) => {
+  if (typeof year === 'string') {
+    year = Number(year)
+  }
+  if (typeof month === 'string') {
+    month = Number(month)
+  }
+
   if (month <= 6) {
     const monthsObject = {}
     const lastYearCount = 7 - month
 
     new Array(lastYearCount).fill(null).forEach((_, idx) => {
-      monthsObject[`${year - 1}-${fillZero(12 - lastYearCount + idx + 1)}`] = 0
+      monthsObject[`${year - 1}-${12 - lastYearCount + idx + 1}`] = 0
     })
 
     new Array(12 - lastYearCount).fill(null).forEach((_, idx) => {
-      monthsObject[`${year}-${fillZero(idx + 1)}`] = 0
+      monthsObject[`${year}-${idx + 1}`] = 0
     })
 
     return monthsObject
   } else {
+    const rightMonthsCount = 5
+    if (month + rightMonthsCount > 12) {
+      const monthsObject = {}
+
+      new Array(24 - (month + rightMonthsCount)).fill(null).forEach((_, idx) => {
+        monthsObject[`${year}-${month - 6 + idx}`] = 0
+      })
+
+      new Array(month + rightMonthsCount - 12).fill(null).forEach((_, idx) => {
+        monthsObject[`${year + 1}-${idx + 1}`] = 0
+      })
+
+      return monthsObject
+    }
+
     return new Array(12).fill(null).reduce((monthsObject, cur, idx) => {
-      monthsObject[`${year}-${fillZero(month - 6 + idx)}`] = 0
+      monthsObject[`${year}-${month - 6 + idx}`] = 0
       return monthsObject
     }, {})
   }

--- a/src/frontend/api/transactionHistory.js
+++ b/src/frontend/api/transactionHistory.js
@@ -12,4 +12,12 @@ const getExpenseTransactionHistoryList = async (year, month) => {
   return data ?? []
 }
 
-export { getTransactionHistoryList, getExpenseTransactionHistoryList }
+const getCategorySixMonthTrend = async (year, month, category) => {
+  const { data } = await fetcher.get(
+    `/transaction/category/six-month?year=${year}&month=${month}&category=${category}`,
+  )
+
+  return data ?? {}
+}
+
+export { getTransactionHistoryList, getExpenseTransactionHistoryList, getCategorySixMonthTrend }

--- a/src/frontend/components/LineChart/LineChart.js
+++ b/src/frontend/components/LineChart/LineChart.js
@@ -60,6 +60,7 @@ export default class LineChart extends Component {
 
     ctx.strokeStyle = '#f5f5f5'
 
+    // 가로 배경선 그리기
     for (let i = 0; i <= ROWS; i++) {
       ctx.beginPath()
       ctx.moveTo(0, gridHeight * i)
@@ -67,6 +68,7 @@ export default class LineChart extends Component {
       ctx.stroke()
     }
 
+    // 세로 배경선 그리기
     for (let i = 0; i <= COLUMNS; i++) {
       ctx.beginPath()
       ctx.moveTo(gridWidth * i, 0)
@@ -102,6 +104,7 @@ export default class LineChart extends Component {
     ctx.lineWidth = 2
     ctx.font = '700 12px Noto Sans KR'
 
+    // 선 그리기
     ctx.beginPath()
     data.forEach((datum, idx) => {
       const xPoint = gridWidth * idx * 2
@@ -115,13 +118,18 @@ export default class LineChart extends Component {
       ctx.stroke()
     })
 
+    // 가격, 점 그리기
     data.forEach((datum, idx) => {
       ctx.beginPath()
       const xPoint = gridWidth * idx * 2
       const yPoint = COORDINATE_HEIGHT - (datum / maxDataValue) * COORDINATE_HEIGHT
+
       if (idx === data.length - 1) {
-        ctx.strokeStyle = '#2ac1bc'
+        ctx.fillStyle = '#2ac1bc'
+      } else {
+        ctx.fillStyle = '#8d9393'
       }
+
       ctx.fillText(priceToString(datum), xPoint, yPoint - 12)
 
       ctx.fillStyle = '#2ac1bc'

--- a/src/frontend/components/LineChart/LineChart.js
+++ b/src/frontend/components/LineChart/LineChart.js
@@ -1,0 +1,134 @@
+import { Component } from '../../core/component.js'
+import { getState, subscribe } from '../../core/observer.js'
+import { selectedCategoryState, sixMonthTrendState } from '../../stores/chartStore.js'
+import { dateState } from '../../stores/dateStore.js'
+import { CATEGORY_EXPENSE } from '../../utils/constants.js'
+import { priceToString } from '../../utils/stringUtil.js'
+import './lineChart.scss'
+
+export const COORDINATE_WIDTH = 750
+export const COORDINATE_HEIGHT = 300
+export const COLUMNS = 22
+export const ROWS = 10
+
+export default class LineChart extends Component {
+  constructor() {
+    super()
+
+    subscribe(selectedCategoryState, this.render.bind(this))
+    subscribe(sixMonthTrendState, this.render.bind(this))
+  }
+
+  template() {
+    const selectedCategory = getState(selectedCategoryState)
+    const category = CATEGORY_EXPENSE[selectedCategory]
+
+    return `
+      <div class="line-board">
+        <p class="line-chart-title">${category} 카테고리 소비 추이</p>
+        <canvas id="grid-canvas" width="750" height="300"></canvas>
+        <div id="months"></div>
+      </div>
+    `
+  }
+
+  componentDidMount() {
+    const { month } = getState(dateState)
+    const sixMonthTrend = getState(sixMonthTrendState)
+    const months = this.getTrendMonthList(sixMonthTrend)
+    const prices = this.getTrendPriceList(sixMonthTrend)
+    this.drawCoordinate(months, month)
+    this.drawLineChart(prices)
+  }
+
+  getTrendMonthList(data) {
+    return Object.keys(data).map((yearMonth) => {
+      return yearMonth.split('-')[1]
+    })
+  }
+
+  getTrendPriceList(data) {
+    return Object.values(data).slice(0, 7)
+  }
+
+  drawCoordinate(months, selectedMonth) {
+    const $canvas = this.querySelector('#grid-canvas')
+    const ctx = $canvas.getContext('2d')
+
+    const gridHeight = COORDINATE_HEIGHT / ROWS
+    const gridWidth = COORDINATE_WIDTH / COLUMNS
+
+    ctx.strokeStyle = '#f5f5f5'
+
+    for (let i = 0; i <= ROWS; i++) {
+      ctx.beginPath()
+      ctx.moveTo(0, gridHeight * i)
+      ctx.lineTo(COORDINATE_WIDTH, gridHeight * i)
+      ctx.stroke()
+    }
+
+    for (let i = 0; i <= COLUMNS; i++) {
+      ctx.beginPath()
+      ctx.moveTo(gridWidth * i, 0)
+      ctx.lineTo(gridWidth * i, COORDINATE_HEIGHT)
+      ctx.stroke()
+    }
+
+    ctx.textAlign = 'center'
+    ctx.font = '700 12px Noto Sans KR'
+
+    for (let i = 0; i <= COLUMNS; i += 2) {
+      const xPoint = gridWidth * i
+      const monthIndex = Math.floor(i / 2)
+      const monthText = months[monthIndex]
+
+      if (selectedMonth === Number(monthText)) {
+        ctx.fillStyle = '#2ac1bc'
+      } else {
+        ctx.fillStyle = '#8d9393'
+      }
+      ctx.fillText(monthText, xPoint, COORDINATE_HEIGHT)
+    }
+  }
+
+  drawLineChart(data) {
+    const $canvas = this.querySelector('#grid-canvas')
+    const ctx = $canvas.getContext('2d')
+
+    const gridWidth = COORDINATE_WIDTH / COLUMNS
+    const maxDataValue = Math.max(...data) * 1.2
+
+    ctx.strokeStyle = '#2ac1bc'
+    ctx.lineWidth = 2
+    ctx.font = '700 12px Noto Sans KR'
+
+    ctx.beginPath()
+    data.forEach((datum, idx) => {
+      const xPoint = gridWidth * idx * 2
+      const yPoint = COORDINATE_HEIGHT - (datum / maxDataValue) * COORDINATE_HEIGHT
+
+      if (!idx) {
+        ctx.moveTo(xPoint, yPoint)
+      } else {
+        ctx.lineTo(xPoint, yPoint)
+      }
+      ctx.stroke()
+    })
+
+    data.forEach((datum, idx) => {
+      ctx.beginPath()
+      const xPoint = gridWidth * idx * 2
+      const yPoint = COORDINATE_HEIGHT - (datum / maxDataValue) * COORDINATE_HEIGHT
+      if (idx === data.length - 1) {
+        ctx.strokeStyle = '#2ac1bc'
+      }
+      ctx.fillText(priceToString(datum), xPoint, yPoint - 12)
+
+      ctx.fillStyle = '#2ac1bc'
+      ctx.arc(xPoint, yPoint, 4, 0, 2 * Math.PI)
+      ctx.fill()
+    })
+  }
+}
+
+customElements.define('line-chart', LineChart)

--- a/src/frontend/components/LineChart/LineChart.js
+++ b/src/frontend/components/LineChart/LineChart.js
@@ -6,8 +6,13 @@ import { CATEGORY_EXPENSE } from '../../utils/constants.js'
 import { priceToString } from '../../utils/stringUtil.js'
 import './lineChart.scss'
 
-export const COORDINATE_WIDTH = 750
-export const COORDINATE_HEIGHT = 300
+export const CHART_WIDTH = 750
+export const CHART_HEIGHT = 300
+export const X_PADDING = 20
+export const Y_PADDING = 20
+
+export const COORDINATE_WIDTH = CHART_WIDTH + X_PADDING
+export const COORDINATE_HEIGHT = CHART_HEIGHT + Y_PADDING
 export const COLUMNS = 22
 export const ROWS = 10
 
@@ -26,7 +31,7 @@ export default class LineChart extends Component {
     return `
       <div class="line-board">
         <p class="line-chart-title">${category} 카테고리 소비 추이</p>
-        <canvas id="grid-canvas" width="750" height="300"></canvas>
+        <canvas id="grid-canvas" width=${COORDINATE_WIDTH} height=${COORDINATE_HEIGHT}></canvas>
         <div id="months"></div>
       </div>
     `
@@ -55,8 +60,8 @@ export default class LineChart extends Component {
     const $canvas = this.querySelector('#grid-canvas')
     const ctx = $canvas.getContext('2d')
 
-    const gridHeight = COORDINATE_HEIGHT / ROWS
-    const gridWidth = COORDINATE_WIDTH / COLUMNS
+    const gridHeight = CHART_HEIGHT / ROWS
+    const gridWidth = CHART_WIDTH / COLUMNS
 
     ctx.strokeStyle = '#f5f5f5'
 
@@ -64,7 +69,7 @@ export default class LineChart extends Component {
     for (let i = 0; i <= ROWS; i++) {
       ctx.beginPath()
       ctx.moveTo(0, gridHeight * i)
-      ctx.lineTo(COORDINATE_WIDTH, gridHeight * i)
+      ctx.lineTo(CHART_WIDTH, gridHeight * i)
       ctx.stroke()
     }
 
@@ -72,13 +77,13 @@ export default class LineChart extends Component {
     for (let i = 0; i <= COLUMNS; i++) {
       ctx.beginPath()
       ctx.moveTo(gridWidth * i, 0)
-      ctx.lineTo(gridWidth * i, COORDINATE_HEIGHT)
+      ctx.lineTo(gridWidth * i, CHART_HEIGHT)
       ctx.stroke()
     }
 
+    // x축 월 글자 그리기
     ctx.textAlign = 'center'
     ctx.font = '700 12px Noto Sans KR'
-
     for (let i = 0; i <= COLUMNS; i += 2) {
       const xPoint = gridWidth * i
       const monthIndex = Math.floor(i / 2)
@@ -97,7 +102,7 @@ export default class LineChart extends Component {
     const $canvas = this.querySelector('#grid-canvas')
     const ctx = $canvas.getContext('2d')
 
-    const gridWidth = COORDINATE_WIDTH / COLUMNS
+    const gridWidth = CHART_WIDTH / COLUMNS
     const maxDataValue = Math.max(...data) * 1.2
 
     ctx.strokeStyle = '#2ac1bc'
@@ -108,7 +113,7 @@ export default class LineChart extends Component {
     ctx.beginPath()
     data.forEach((datum, idx) => {
       const xPoint = gridWidth * idx * 2
-      const yPoint = COORDINATE_HEIGHT - (datum / maxDataValue) * COORDINATE_HEIGHT
+      const yPoint = CHART_HEIGHT - (datum / maxDataValue) * CHART_HEIGHT
 
       if (!idx) {
         ctx.moveTo(xPoint, yPoint)
@@ -122,7 +127,7 @@ export default class LineChart extends Component {
     data.forEach((datum, idx) => {
       ctx.beginPath()
       const xPoint = gridWidth * idx * 2
-      const yPoint = COORDINATE_HEIGHT - (datum / maxDataValue) * COORDINATE_HEIGHT
+      const yPoint = CHART_HEIGHT - (datum / maxDataValue) * CHART_HEIGHT
 
       if (idx === data.length - 1) {
         ctx.fillStyle = '#2ac1bc'

--- a/src/frontend/components/LineChart/lineChart.scss
+++ b/src/frontend/components/LineChart/lineChart.scss
@@ -1,0 +1,20 @@
+@import '../../styles/color.scss';
+@import '../../styles//text-style.scss';
+
+.line-board {
+  margin-top: 16px;
+  padding: 35px 42px 32px 42px;
+
+  width: 848px;
+
+  background-color: #ffffff;
+
+  border: 1px solid #d7d7d7;
+  border-radius: 10px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.line-chart-title {
+  @include body-large-text;
+  margin-bottom: 32px;
+}

--- a/src/frontend/pages/ChartPage/ChartPage.js
+++ b/src/frontend/pages/ChartPage/ChartPage.js
@@ -1,10 +1,8 @@
 import DoughnutChart from '../../components/DoughnutChart/DoughnutChart.js'
+import LineChart from '../../components/LineChart/LineChart.js'
 import { Component } from '../../core/component.js'
 import { getState, subscribe } from '../../core/observer.js'
-import {
-  selectedCategoryState,
-  selectedCategoryTransactionListState,
-} from '../../stores/chartStore.js'
+import { selectedCategoryState } from '../../stores/chartStore.js'
 import './chartPage.scss'
 
 export default class ChartPage extends Component {
@@ -12,14 +10,13 @@ export default class ChartPage extends Component {
     super()
 
     subscribe(selectedCategoryState, this.render.bind(this))
-    subscribe(selectedCategoryTransactionListState, this.render.bind(this))
   }
   template() {
     return /*html*/ `
     <div class="chart-page-container">
        <div class="chart-page-wrapper">
         <div id="doughnut-chart-replace"></div>
-
+        <div id="line-chart-replace"></div>
 
         <div class="category-transaction-list">
         </div>
@@ -31,6 +28,12 @@ export default class ChartPage extends Component {
   setComponent() {
     const $doughnutChartReplace = this.querySelector('#doughnut-chart-replace')
     $doughnutChartReplace.replaceWith(new DoughnutChart())
+
+    const selectedCategory = getState(selectedCategoryState)
+    if (!selectedCategory) return
+
+    const $lineChartReplace = this.querySelector('#line-chart-replace')
+    $lineChartReplace.replaceWith(new LineChart())
   }
 }
 customElements.define('chart-container', ChartPage)

--- a/src/frontend/stores/chartStore.js
+++ b/src/frontend/stores/chartStore.js
@@ -10,7 +10,7 @@ export const selectedCategoryState = initState({
   defaultValue: '',
 })
 
-export const selectedCategoryTransactionListState = initState({
-  key: 'chart/selectedCategoryTransactionListState',
-  defaultValue: [],
+export const sixMonthTrendState = initState({
+  key: 'chart/sixMonthTrendState',
+  defaultValue: {},
 })


### PR DESCRIPTION
## 📑 개요

라인차트 구현

## 📎 관련 이슈

close #36 

## 💬 작업 내용

6개월 카테고리별 지출내역 추이 api의 반환값을 수정했습니다.

기존에는 7개월에 대한 정보만 보냈지만, 이제는 12개월에 대한 정보를 보냅니다.
이렇게 한 이유는 프론트엔드에서 라인차트를 그리기 편하게 하기 위해서 이렇게 했습니다.


도넛 차트 카테고리 클릭하면 라인차트 뜨도록 구현했습니다.

라인차트 좌표계 그리기 구현했습니다.
라인차트 라인 그리기 구현했습니다.
라인차트 가격 텍스트 및 점 그리기 구현했습니다.


## 🖼 스크린샷(추가사항)

<img width="816" alt="스크린샷 2022-07-27 오전 1 11 54" src="https://user-images.githubusercontent.com/60956392/181058369-c12ce449-09d7-44c2-816a-9e7b5bec14be.png">


## 🚧 PR 특이 사항

현재 좌표계를 캔버스 꽉차게 구현했는데, 이렇게 하니까 x축의 월 표시와 0원일 때 line이 제대로 안보이는 문제가 발생합니다.

일단 이 이슈는 나중에 처리하도록 하겠습니다.

