### PR TITLE
Fix/68/calendar-october

### DIFF
--- a/src/frontend/pages/CalendarPage/CalendarPage.js
+++ b/src/frontend/pages/CalendarPage/CalendarPage.js
@@ -5,7 +5,7 @@ import { dateState } from '../../stores/dateStore.js'
 import { KR_WEEK } from '../../utils/constants.js'
 import { calculateTransaction, classifyTransactionDataByDate } from '../../utils/transactionUtil.js'
 import { isToday } from '../../utils/calendar.js'
-import { priceToString } from '../../utils/stringUtil.js'
+import { priceToString, fillZero } from '../../utils/stringUtil.js'
 import { transactionListState } from '../../stores/transactionStore.js'
 import './calendarPage.scss'
 
@@ -65,13 +65,13 @@ export default class CalendarPage extends Component {
               }
 
               const hasPriceData = Object.keys(classifiedData).includes(
-                `${year}-${month > 10 ? month : `0${month}`}-${date}`,
+                `${year}-${fillZero(month)}-${date}`,
               )
 
               let income, expense
               if (hasPriceData) {
                 const [inc, exp] = calculateTransaction(
-                  classifiedData[`${year}-${month > 10 ? month : `0${month}`}-${date}`],
+                  classifiedData[`${year}-${fillZero(month)}-${date}`],
                 )
                 income = inc
                 expense = -exp

--- a/src/frontend/utils/stringUtil.js
+++ b/src/frontend/utils/stringUtil.js
@@ -2,4 +2,8 @@ const priceToString = (price) => {
   return Number(price).toLocaleString()
 }
 
-export { priceToString }
+const fillZero = (number) => {
+  return number < 10 ? `0${number}` : number
+}
+
+export { priceToString, fillZero }


### PR DESCRIPTION
## 📑 개요

한자리 수 숫자 0 붙여주는 로직 10일 때 안되던 것 수정

## 📎 관련 이슈

close #68 

## 💬 작업 내용

이전에 아래와 같이 잘못 작성해서, 10도 0이 붙어버렸습니다.
이 부분 수정했고, 따로 util 함수로 만들었습니다.

```
number > 10 ? number : `0${number}` 
 ```


## 🖼 스크린샷(추가사항)

<img width="1124" alt="스크린샷 2022-07-27 오후 4 07 43" src="https://user-images.githubusercontent.com/60956392/181183868-aabe1bcc-c209-4165-9aae-b821b57e0ae1.png">



## 🚧 PR 특이 사항
