### PR TITLE
Fix/53/price comma

### DIFF
--- a/src/frontend/components/TransactionList/TransactionList.js
+++ b/src/frontend/components/TransactionList/TransactionList.js
@@ -6,6 +6,7 @@ import DateTransactionList from '../DateTransactionList/DateTransactionList.js'
 import './transactionList.scss'
 import IconCheckboxDefault from '../../assets/checkbox-default.svg'
 import IconCheckboxActive from '../../assets/checkbox-active.svg'
+import { priceToString } from '../../utils/stringUtil.js'
 
 export default class TransactionList extends Component {
   constructor(props) {
@@ -38,12 +39,12 @@ export default class TransactionList extends Component {
                 <input type="checkbox" id="filter-income" ${incomeChecked ? 'checked' : ''} />
                 <label for="filter-income" class="${!incomeChecked ? 'unchecked' : ''}">
                   <i>${incomeChecked ? IconCheckboxActive : IconCheckboxDefault}</i>
-                  수입 ${totalIncome}
+                  수입 ${priceToString(totalIncome)}
                 </label>
                 <input type="checkbox" id="filter-expense" ${expenseChecked ? 'checked' : ''} />
                 <label for="filter-expense"  class="${!expenseChecked ? 'unchecked' : ''}">
                 <i>${expenseChecked ? IconCheckboxActive : IconCheckboxDefault}</i>
-                  지출 ${totalExpense}
+                  지출 ${priceToString(totalExpense)}
                 </label>
               </div>
               </div>


### PR DESCRIPTION
## 📑 개요

메인 페이지 수입, 지출 필터 콤마 없는 버그 수정

## 📎 관련 이슈

close #53

## 💬 작업 내용

`priceToString` 으로 수입, 지출 숫자를 감싸주었습니다.

## 🖼 스크린샷(추가사항)

<img width="999" alt="스크린샷 2022-07-27 오후 4 22 59" src="https://user-images.githubusercontent.com/60956392/181186824-657c7244-90bb-41a1-bfcd-9f483cae7724.png">


## 🚧 PR 특이 사항
