### PR TITLE
Feat/31/add payment api

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv'
-import createError from 'http-errors'
 import express from 'express'
 import path from 'path'
 import cookieParser from 'cookie-parser'
@@ -9,6 +8,7 @@ import webpackDevConfig from '../../webpack.dev.js'
 import webpackProdConfig from '../../webpack.prod.js'
 import Middleware from 'webpack-dev-middleware'
 import { transactionRouter } from './routes/transactionHistory.js'
+import { paymentRouter } from './routes/payment.js'
 
 dotenv.config()
 const __dirname = path.resolve()
@@ -32,6 +32,7 @@ app.use(
 )
 
 app.use('/api/transaction', transactionRouter)
+app.use('/api/payment', paymentRouter)
 
 app.get('/*', (req, res) => {
   res.sendFile(path.resolve(__dirname, `public/index.html`))

--- a/src/backend/controllers/payment.js
+++ b/src/backend/controllers/payment.js
@@ -1,0 +1,14 @@
+import { PaymentService } from '../services/payment.js'
+
+const createPayment = async (req, res) => {
+  const { name } = req.body
+  const data = await PaymentService.createPayment(name)
+
+  res.status(200).send({
+    data: {
+      id: data.insertId,
+    },
+  })
+}
+
+export { createPayment }

--- a/src/backend/routes/payment.js
+++ b/src/backend/routes/payment.js
@@ -1,0 +1,8 @@
+import express from 'express'
+import { createPayment } from '../controllers/payment.js'
+
+const paymentRouter = express.Router()
+
+paymentRouter.post('/', createPayment)
+
+export { paymentRouter }

--- a/src/backend/services/payment.js
+++ b/src/backend/services/payment.js
@@ -1,0 +1,13 @@
+import Payment from '../models/payment.js'
+
+const PaymentService = {
+  createPayment: async (paymentName) => {
+    const response = await Payment.create({
+      name: paymentName,
+    })
+
+    return response
+  },
+}
+
+export { PaymentService }


### PR DESCRIPTION
## 📑 개요

결제수단 추가 API 구현

## 📎 관련 이슈

close #31

## 💬 작업 내용

결제수단 추가 API 서비스, 컨트롤러, 라우트 나누어 구현했습니다.

성공적으로 결제수단이 추가되면 id로 추가된 결제 수단의 id를 반환합니다.

## 🚧 PR 특이 사항
