### PR TITLE
Feat/73/delete payment api

### DIFF
--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,5 +1,4 @@
 import dotenv from 'dotenv'
-import createError from 'http-errors'
 import express from 'express'
 import path from 'path'
 import cookieParser from 'cookie-parser'
@@ -9,6 +8,7 @@ import webpackDevConfig from '../../webpack.dev.js'
 import webpackProdConfig from '../../webpack.prod.js'
 import Middleware from 'webpack-dev-middleware'
 import { transactionRouter } from './routes/transactionHistory.js'
+import { paymentRouter } from './routes/payment.js'
 
 dotenv.config()
 const __dirname = path.resolve()
@@ -32,6 +32,7 @@ app.use(
 )
 
 app.use('/api/transaction', transactionRouter)
+app.use('/api/payment', paymentRouter)
 
 app.get('/*', (req, res) => {
   res.sendFile(path.resolve(__dirname, `public/index.html`))

--- a/src/backend/controllers/payment.js
+++ b/src/backend/controllers/payment.js
@@ -1,0 +1,14 @@
+import { PaymentService } from '../services/payment.js'
+
+const createPayment = async (req, res) => {
+  const { name } = req.body
+  const data = await PaymentService.createPayment(name)
+
+  res.status(200).send({
+    data: {
+      id: data.insertId,
+    },
+  })
+}
+
+export { createPayment }

--- a/src/backend/controllers/payment.js
+++ b/src/backend/controllers/payment.js
@@ -19,4 +19,11 @@ const createPayment = async (req, res) => {
   })
 }
 
-export { getPayment, createPayment }
+const deletePayment = async (req, res) => {
+  const { id } = req.params
+  const data = await PaymentService.deletePayment(id)
+
+  res.status(200).send()
+}
+
+export { getPayment, createPayment, deletePayment }

--- a/src/backend/controllers/payment.js
+++ b/src/backend/controllers/payment.js
@@ -1,5 +1,13 @@
 import { PaymentService } from '../services/payment.js'
 
+const getPayment = async (req, res) => {
+  const data = await PaymentService.getPayment()
+
+  res.status(200).send({
+    data,
+  })
+}
+
 const createPayment = async (req, res) => {
   const { name } = req.body
   const data = await PaymentService.createPayment(name)
@@ -11,4 +19,4 @@ const createPayment = async (req, res) => {
   })
 }
 
-export { createPayment }
+export { getPayment, createPayment }

--- a/src/backend/routes/payment.js
+++ b/src/backend/routes/payment.js
@@ -1,0 +1,8 @@
+import express from 'express'
+import { createPayment } from '../controllers/payment.js'
+
+const paymentRouter = express.Router()
+
+paymentRouter.post('/', createPayment)
+
+export { paymentRouter }

--- a/src/backend/routes/payment.js
+++ b/src/backend/routes/payment.js
@@ -1,8 +1,9 @@
 import express from 'express'
-import { createPayment } from '../controllers/payment.js'
+import { createPayment, getPayment } from '../controllers/payment.js'
 
 const paymentRouter = express.Router()
 
+paymentRouter.get('/', getPayment)
 paymentRouter.post('/', createPayment)
 
 export { paymentRouter }

--- a/src/backend/routes/payment.js
+++ b/src/backend/routes/payment.js
@@ -1,9 +1,10 @@
 import express from 'express'
-import { createPayment, getPayment } from '../controllers/payment.js'
+import { createPayment, deletePayment, getPayment } from '../controllers/payment.js'
 
 const paymentRouter = express.Router()
 
 paymentRouter.get('/', getPayment)
 paymentRouter.post('/', createPayment)
+paymentRouter.delete('/:id', deletePayment)
 
 export { paymentRouter }

--- a/src/backend/services/payment.js
+++ b/src/backend/services/payment.js
@@ -1,6 +1,16 @@
 import Payment from '../models/payment.js'
 
 const PaymentService = {
+  getPayment: async () => {
+    const response = await Payment.findAll({
+      attributes: ['id', 'name'],
+      where: {
+        is_deleted: 0,
+      },
+    })
+
+    return response
+  },
   createPayment: async (paymentName) => {
     const response = await Payment.create({
       name: paymentName,

--- a/src/backend/services/payment.js
+++ b/src/backend/services/payment.js
@@ -18,6 +18,20 @@ const PaymentService = {
 
     return response
   },
+  deletePayment: async (paymentId) => {
+    const response = await Payment.update(
+      {
+        is_deleted: 1,
+      },
+      {
+        where: {
+          id: paymentId,
+        },
+      },
+    )
+
+    return response
+  },
 }
 
 export { PaymentService }

--- a/src/backend/services/payment.js
+++ b/src/backend/services/payment.js
@@ -1,0 +1,13 @@
+import Payment from '../models/payment.js'
+
+const PaymentService = {
+  createPayment: async (paymentName) => {
+    const response = await Payment.create({
+      name: paymentName,
+    })
+
+    return response
+  },
+}
+
+export { PaymentService }


### PR DESCRIPTION
## 📑 개요

결제수단 삭제 API 구현

## 📎 관련 이슈

close #73

## 💬 작업 내용

결제수단 삭제 API를 구현했습니다.

DELETE `/api/payment/:id` 로 api를 보내고, 해당 id의 결제수단의 `is_deleted` 를 1로 수정합니다.

## 🚧 PR 특이 사항

DB에서 해당 결제수단 데이터를 삭제하는 것이 아닌 is_delete라는 필드의 0/1 로 삭제를 판단합니다.

이렇게 한 이유는, 결제수단이 삭제되었을 때, 결제수단을 바라보고 있는 거래내역 테이블을 건드릴 필요가 없다는 장점이 있어서 이렇게 민수님과 결정했습니다.

거래내역 GET 요청 시에는 결제수단 X 거래내역 JOIN 하여 is_deleted가 0인 값만 리턴해줍니다.
