### PR TITLE
Feat/37/create payment submit

### DIFF
--- a/src/frontend/components/CategoryDropdown/CategoryDropdown.js
+++ b/src/frontend/components/CategoryDropdown/CategoryDropdown.js
@@ -31,7 +31,7 @@ export default class CategoryDropdown extends Component {
     const $item = e.target.closest('.dropdown-li')
     const selectedItem = $item.id
     const option = e.target.classList.contains('true')
-    this.props.setCategoryItem(selectedItem, option)
+    this.props.handleInputCategory(selectedItem, option)
   }
 }
 

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -5,7 +5,7 @@ import minus from '../../assets/minus.svg'
 import plus from '../../assets/plus.svg'
 import CategoryDropdown from '../CategoryDropdown/CategoryDropdown.js'
 import PaymentDropdown from '../PaymentDropdown/PaymentDropdown.js'
-import { todayDate } from '../../utils/stringUtil.js'
+import { priceToString, todayDate } from '../../utils/stringUtil.js'
 import { createTransactionAPI } from '../../api/transactionHistory.js'
 
 export default class PaymentBar extends Component {
@@ -153,7 +153,7 @@ export default class PaymentBar extends Component {
 
   // 가격 입력 정규 표현식
   PriceRegExp(e) {
-    e.target.value = Number(e.target.value.replace(/[^0-9]/g, '')).toLocaleString()
+    e.target.value = priceToString(e.target.value.replace(/[^0-9]/g, ''))
   }
 
   /* 필드 입력 관련 함수 */

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -26,7 +26,7 @@ export default class PaymentBar extends Component {
         <form class='form-wrapper'>
             <div class='form-element'>
                 <span class='form-element-title'>일자</span>
-                <input class='form-element-input' id='paymentDate' placeholder='yyyymmdd' value=${paymentDate}>
+                <input class='form-element-input' id='paymentDate' placeholder='yyyymmdd' maxlength='10' value=${paymentDate}>
             </div>
             <div class='form-element category-form'>
                 <span class='form-element-title'>분류</span>
@@ -61,7 +61,7 @@ export default class PaymentBar extends Component {
                         <span>원</span>
                     </div>
                 </div>
-            <button class='form-button'>
+            <button class='form-button' disabled>
             ${plus}
             </button>
         </form>
@@ -70,24 +70,29 @@ export default class PaymentBar extends Component {
   }
 
   setEvent() {
+    // 각 입력 필드별로 다른 예외 처리를 해야하므로 각각의 이벤트 할당
+
+    const $paymentDate = this.querySelector('#paymentDate')
+    $paymentDate.addEventListener('keyup', this.handleInputPaymentDate.bind(this))
+    $paymentDate.addEventListener('change', this.handleInputPaymentDateState.bind(this))
+
+    this.querySelector('#title').addEventListener('change', this.handleInputTitle.bind(this))
+
     const $categorySelectList = this.querySelectorAll('.select-dropdown')
     $categorySelectList.forEach((item) =>
       item.addEventListener('click', this.handleClickCategorySelect.bind(this)),
     )
-
-    const $formInput = this.querySelectorAll('.form-element-input')
-    $formInput.forEach(($input) => $input.addEventListener('change', this.handleInput.bind(this)))
   }
 
   setComponent() {
     const $categoryDropdownElement = this.querySelector('.category-dropdown-category')
     $categoryDropdownElement.appendChild(
-      new CategoryDropdown({ setCategoryItem: this.setCategoryItem.bind(this) }),
+      new CategoryDropdown({ handleInputCategory: this.handleInputCategory.bind(this) }),
     )
 
     const $paymentDropdownElement = this.querySelector('.category-dropdown-payment')
     $paymentDropdownElement.appendChild(
-      new PaymentDropdown({ setPaymentItem: this.setPaymentItem.bind(this) }),
+      new PaymentDropdown({ handleInputPaymentId: this.handleInputPaymentId.bind(this) }),
     )
   }
 
@@ -99,23 +104,49 @@ export default class PaymentBar extends Component {
     }
   }
 
-  setCategoryItem(selectedItem, option) {
+  // 날짜 입력 값 정규 표현식
+  handleInputPaymentDate(e) {
+    e.target.value = e.target.value
+      .replace(/[^0-9]/g, '')
+      .replace(/^(\d{0,4})(\d{0,2})(\d{0,2})$/g, '$1-$2-$3')
+      .replace(/\-{1,2}$/g, '')
+      .replace()
+  }
+
+  // 필드 입력 관련 함수
+
+  // 날짜 입력 폼
+  handleInputPaymentDateState(e) {
+    this.setState({
+      paymentDate: e.target.value,
+    })
+  }
+
+  // 카테고리 입력 폼
+  handleInputCategory(selectedItem, option) {
     this.setState({
       category: selectedItem,
       option: option,
     })
   }
 
-  setPaymentItem(selectedItem) {
+  // 내용 입력 폼
+  handleInputTitle(e) {
+    this.setState({
+      title: e.target.value,
+    })
+  }
+
+  // 결제수단 입력 폼
+  handleInputPaymentId(selectedItem) {
     this.setState({
       payment_id: 2,
     })
   }
 
-  handleInput(e) {
-    const { id } = e.target
+  handleInputPrice(e) {
     this.setState({
-      [id]: e.target.value,
+      title: e.target.value,
     })
   }
 }

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -5,25 +5,28 @@ import minus from '../../assets/minus.svg'
 import plus from '../../assets/plus.svg'
 import CategoryDropdown from '../CategoryDropdown/CategoryDropdown.js'
 import PaymentDropdown from '../PaymentDropdown/PaymentDropdown.js'
+import { todayDate } from '../../utils/stringUtil.js'
+import { createTransactionAPI } from '../../api/transactionHistory.js'
 
 export default class PaymentBar extends Component {
   initState() {
     this.state = {
-      paymentDate: '',
+      paymentDate: todayDate(),
       category: '',
       title: '',
       payment_id: 0,
       price: 0,
       option: false,
+      disabled: true,
     }
   }
 
   template() {
-    const { paymentDate, category, title, payment_id, price, option } = this.state
+    const { paymentDate, category, title, payment_id, price, option, disabled } = this.state
 
     return /*html*/ `
     <div class='paymentbar-container'>
-        <form class='form-wrapper'>
+        <div class='form-wrapper'>
             <div class='form-element'>
                 <span class='form-element-title'>일자</span>
                 <input class='form-element-input' id='paymentDate' placeholder='yyyymmdd' maxlength='10' value=${paymentDate}>
@@ -61,22 +64,27 @@ export default class PaymentBar extends Component {
                         <span>원</span>
                     </div>
                 </div>
-            <button class='form-button' disabled>
-            ${plus}
+            <button class='form-button'>
+              ${plus}
             </button>
-        </form>
+        </div>
     </div>
     `
   }
 
   setEvent() {
     // 각 입력 필드별로 다른 예외 처리를 해야하므로 각각의 이벤트 할당
-
     const $paymentDate = this.querySelector('#paymentDate')
-    $paymentDate.addEventListener('keyup', this.handleInputPaymentDate.bind(this))
-    $paymentDate.addEventListener('change', this.handleInputPaymentDateState.bind(this))
+    $paymentDate.addEventListener('input', this.PaymentDataRegExp.bind(this))
+    $paymentDate.addEventListener('change', this.handleInputPaymentDate.bind(this))
 
     this.querySelector('#title').addEventListener('change', this.handleInputTitle.bind(this))
+
+    const $price = this.querySelector('#price')
+    $price.addEventListener('input', this.PriceRegExp.bind(this))
+    $price.addEventListener('change', this.handleInputPrice.bind(this))
+
+    this.querySelector('.form-button').addEventListener('click', this.submitForm.bind(this))
 
     const $categorySelectList = this.querySelectorAll('.select-dropdown')
     $categorySelectList.forEach((item) =>
@@ -96,6 +104,23 @@ export default class PaymentBar extends Component {
     )
   }
 
+  submitForm(e) {
+    const result = e.target.closest('.submit')
+    if (!result) return
+
+    const { paymentDate, category, title, payment_id, price, option } = this.state
+    let tmpPrice = Number(price.replace(/,/g, ''))
+    tmpPrice = option ? tmpPrice : -tmpPrice
+    const data = {
+      paymentDate,
+      category,
+      title,
+      payment_id,
+      price: tmpPrice,
+    }
+    createTransactionAPI(data)
+  }
+
   handleClickCategorySelect(e) {
     const { id } = e.target
     if (id) {
@@ -104,8 +129,22 @@ export default class PaymentBar extends Component {
     }
   }
 
+  checkFormButton() {
+    const check = Object.values(this.state).every((state) => state !== '' && state !== 0)
+
+    this.setState({
+      disabled: !check,
+    })
+
+    if (check) {
+      this.querySelector('.form-button').classList.add('submit')
+    } else {
+      this.querySelector('.form-button').classList.remove('submit')
+    }
+  }
+
   // 날짜 입력 값 정규 표현식
-  handleInputPaymentDate(e) {
+  PaymentDataRegExp(e) {
     e.target.value = e.target.value
       .replace(/[^0-9]/g, '')
       .replace(/^(\d{0,4})(\d{0,2})(\d{0,2})$/g, '$1-$2-$3')
@@ -113,13 +152,19 @@ export default class PaymentBar extends Component {
       .replace()
   }
 
-  // 필드 입력 관련 함수
+  // 가격 입력 정규 표현식
+  PriceRegExp(e) {
+    e.target.value = Number(e.target.value.replace(/[^0-9]/g, '')).toLocaleString()
+  }
+
+  /* 필드 입력 관련 함수 */
 
   // 날짜 입력 폼
-  handleInputPaymentDateState(e) {
+  handleInputPaymentDate(e) {
     this.setState({
       paymentDate: e.target.value,
     })
+    this.checkFormButton()
   }
 
   // 카테고리 입력 폼
@@ -128,6 +173,7 @@ export default class PaymentBar extends Component {
       category: selectedItem,
       option: option,
     })
+    this.checkFormButton()
   }
 
   // 내용 입력 폼
@@ -135,6 +181,7 @@ export default class PaymentBar extends Component {
     this.setState({
       title: e.target.value,
     })
+    this.checkFormButton()
   }
 
   // 결제수단 입력 폼
@@ -142,12 +189,15 @@ export default class PaymentBar extends Component {
     this.setState({
       payment_id: 2,
     })
+    this.checkFormButton()
   }
 
+  // 가격 입력 폼
   handleInputPrice(e) {
     this.setState({
-      title: e.target.value,
+      price: e.target.value,
     })
+    this.checkFormButton()
   }
 }
 

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -75,18 +75,17 @@ export default class PaymentBar extends Component {
   setEvent() {
     // 각 입력 필드별로 다른 예외 처리를 해야하므로 각각의 이벤트 할당
     const $paymentDate = this.querySelector('#paymentDate')
+    const $title = this.querySelector('#title')
+    const $price = this.querySelector('#price')
+    const $formButton = this.querySelector('.form-button')
+    const $categorySelectList = this.querySelectorAll('.select-dropdown')
+
     $paymentDate.addEventListener('input', this.PaymentDataRegExp.bind(this))
     $paymentDate.addEventListener('change', this.handleInputPaymentDate.bind(this))
-
-    this.querySelector('#title').addEventListener('change', this.handleInputTitle.bind(this))
-
-    const $price = this.querySelector('#price')
-    $price.addEventListener('input', this.PriceRegExp.bind(this))
+    $title.addEventListener('change', this.handleInputTitle.bind(this))
+    $price.addEventListener('input', this.priceRegExp.bind(this))
     $price.addEventListener('change', this.handleInputPrice.bind(this))
-
-    this.querySelector('.form-button').addEventListener('click', this.submitForm.bind(this))
-
-    const $categorySelectList = this.querySelectorAll('.select-dropdown')
+    $formButton.addEventListener('click', this.submitForm.bind(this))
     $categorySelectList.forEach((item) =>
       item.addEventListener('click', this.handleClickCategorySelect.bind(this)),
     )
@@ -144,7 +143,7 @@ export default class PaymentBar extends Component {
   }
 
   // 날짜 입력 값 정규 표현식
-  PaymentDataRegExp(e) {
+  paymentDataRegExp(e) {
     e.target.value = e.target.value
       .replace(/[^0-9]/g, '')
       .replace(/^(\d{0,4})(\d{0,2})(\d{0,2})$/g, '$1-$2-$3')

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -80,7 +80,7 @@ export default class PaymentBar extends Component {
     const $formButton = this.querySelector('.form-button')
     const $categorySelectList = this.querySelectorAll('.select-dropdown')
 
-    $paymentDate.addEventListener('input', this.PaymentDataRegExp.bind(this))
+    $paymentDate.addEventListener('input', this.paymentDataRegExp.bind(this))
     $paymentDate.addEventListener('change', this.handleInputPaymentDate.bind(this))
     $title.addEventListener('change', this.handleInputTitle.bind(this))
     $price.addEventListener('input', this.priceRegExp.bind(this))
@@ -152,7 +152,7 @@ export default class PaymentBar extends Component {
   }
 
   // 가격 입력 정규 표현식
-  PriceRegExp(e) {
+  priceRegExp(e) {
     e.target.value = priceToString(e.target.value.replace(/[^0-9]/g, ''))
   }
 

--- a/src/frontend/components/PaymentBar/paymentbar.scss
+++ b/src/frontend/components/PaymentBar/paymentbar.scss
@@ -81,6 +81,7 @@
   @include body-regular-text;
   width: 100%;
   border: none;
+  background-color: $color-off-white;
 
   &::placeholder {
     color: $color-label;

--- a/src/frontend/components/PaymentBar/paymentbar.scss
+++ b/src/frontend/components/PaymentBar/paymentbar.scss
@@ -101,16 +101,26 @@
   /* Primary1 */
   border: 2px solid #2ac1bc;
   border-radius: 10px;
+  background-color: $color-off-white;
+  svg {
+    width: 24px;
+    path {
+      stroke: $color-primary-200;
+    }
+  }
 
   /* Inside auto layout */
   flex: none;
   order: 1;
   flex-grow: 0;
 
-  svg {
-    width: 24px;
-    path {
-      stroke: $color-primary-200;
+  &.submit {
+    background-color: $color-primary-200;
+    svg {
+      width: 24px;
+      path {
+        stroke: $color-off-white;
+      }
     }
   }
 }

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -36,7 +36,7 @@ export default class PaymentDropdown extends Component {
   handleClickCategoryItem(e) {
     const $item = e.target.closest('.dropdown-li')
     const paymentItem = $item.id
-    this.props.setPaymentItem(paymentItem)
+    this.props.handleInputPaymentId(paymentItem)
   }
 }
 

--- a/src/frontend/stores/dateStore.js
+++ b/src/frontend/stores/dateStore.js
@@ -1,9 +1,13 @@
 import { initState } from '../core/observer.js'
 
+const now = new Date() // 현재 날짜 및 시간
+const year = now.getFullYear()
+const month = now.getMonth() + 1
+
 export const dateState = initState({
   key: 'dateState',
   defaultValue: {
-    year: 2021,
-    month: 6,
+    year,
+    month,
   },
 })

--- a/src/frontend/utils/stringUtil.js
+++ b/src/frontend/utils/stringUtil.js
@@ -3,18 +3,10 @@ const priceToString = (price) => {
 }
 
 const todayDate = () => {
-  const leftPad = (value) => {
-    if (value >= 10) {
-      return value
-    }
-
-    return `0${value}`
-  }
-
   const date = new Date()
   const year = date.getFullYear()
-  const month = leftPad(date.getMonth() + 1)
-  const day = leftPad(date.getDate())
+  const month = fillZero(date.getMonth() + 1)
+  const day = fillZero(date.getDate())
 
   return [year, month, day].join('-')
 }

--- a/src/frontend/utils/stringUtil.js
+++ b/src/frontend/utils/stringUtil.js
@@ -2,4 +2,21 @@ const priceToString = (price) => {
   return Number(price).toLocaleString()
 }
 
-export { priceToString }
+const todayDate = () => {
+  const leftPad = (value) => {
+    if (value >= 10) {
+      return value
+    }
+
+    return `0${value}`
+  }
+
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = leftPad(date.getMonth() + 1)
+  const day = leftPad(date.getDate())
+
+  return [year, month, day].join('-')
+}
+
+export { priceToString, todayDate }


### PR DESCRIPTION
## 📑 개요

결제 내역 생성 로직 개발해서 정상적으로 데이터가 추가됩니다.

## 📎 관련 이슈

close #37 

## 💬 작업 내용

- 각 입력폼마다 이벤트 등록 및 입력 값 저장 및 예외처리
- 날짜 이벤트 입력시, 자동 - 삽입 정규 표현식 처리
- 분류 드롭다운 선택 시 해당 id값 저장
- 내용 입력 저장
- 금액 세 자리 수마다 , 삽입 정규 표현식
- 금액 (수입, 지출에 따른 분기 처리)

## 🖼 스크린샷(추가사항)
입력 폼 작성
<img width="970" alt="스크린샷 2022-07-27 오후 6 38 03" src="https://user-images.githubusercontent.com/52727782/181215427-7d693b17-f88d-4c8a-94a8-86371ab58ff2.png">

추가된 데이터 확인
<img width="970" alt="스크린샷 2022-07-27 오후 6 38 27" src="https://user-images.githubusercontent.com/52727782/181215539-6cbc7f4b-377a-4656-85e0-aae733831d28.png">

## 🚧 PR 특이 사항
결제 수단 기능이 아직 개발되지않아 결제수단 id값을 하드코딩으로 적용했습니다.
나중에 결제 수단 완성 시, 해당 로직을 붙이면 될 것 같습니다!
