### PR TITLE
Feat/79/canvas Enhancement

### DIFF
--- a/src/frontend/components/LineChart/LineChart.js
+++ b/src/frontend/components/LineChart/LineChart.js
@@ -6,10 +6,10 @@ import { CATEGORY_EXPENSE } from '../../utils/constants.js'
 import { priceToString } from '../../utils/stringUtil.js'
 import './lineChart.scss'
 
-export const CHART_WIDTH = 750
-export const CHART_HEIGHT = 300
-export const X_PADDING = 20
-export const Y_PADDING = 20
+export const CHART_WIDTH = 1500
+export const CHART_HEIGHT = 600
+export const X_PADDING = 80
+export const Y_PADDING = 80
 
 export const COORDINATE_WIDTH = CHART_WIDTH + X_PADDING
 export const COORDINATE_HEIGHT = CHART_HEIGHT + Y_PADDING
@@ -31,7 +31,7 @@ export default class LineChart extends Component {
     return `
       <div class="line-board">
         <p class="line-chart-title">${category} 카테고리 소비 추이</p>
-        <canvas id="grid-canvas" width=${COORDINATE_WIDTH} height=${COORDINATE_HEIGHT}></canvas>
+        <canvas id="grid-canvas" class="line-chart" width="1600" height="680"></canvas>
         <div id="months"></div>
       </div>
     `
@@ -68,24 +68,24 @@ export default class LineChart extends Component {
     // 가로 배경선 그리기
     for (let i = 0; i <= ROWS; i++) {
       ctx.beginPath()
-      ctx.moveTo(0, gridHeight * i)
-      ctx.lineTo(CHART_WIDTH, gridHeight * i)
+      ctx.moveTo(X_PADDING, gridHeight * i + Y_PADDING)
+      ctx.lineTo(CHART_WIDTH + X_PADDING, gridHeight * i + Y_PADDING)
       ctx.stroke()
     }
 
     // 세로 배경선 그리기
     for (let i = 0; i <= COLUMNS; i++) {
       ctx.beginPath()
-      ctx.moveTo(gridWidth * i, 0)
-      ctx.lineTo(gridWidth * i, CHART_HEIGHT)
+      ctx.moveTo(gridWidth * i + X_PADDING, Y_PADDING)
+      ctx.lineTo(gridWidth * i + X_PADDING, CHART_HEIGHT + Y_PADDING)
       ctx.stroke()
     }
 
     // x축 월 글자 그리기
     ctx.textAlign = 'center'
-    ctx.font = '700 12px Noto Sans KR'
+    ctx.font = '700 24px Noto Sans KR'
     for (let i = 0; i <= COLUMNS; i += 2) {
-      const xPoint = gridWidth * i
+      const xPoint = gridWidth * i + X_PADDING
       const monthIndex = Math.floor(i / 2)
       const monthText = months[monthIndex]
 
@@ -106,13 +106,13 @@ export default class LineChart extends Component {
     const maxDataValue = Math.max(...data) * 1.2
 
     ctx.strokeStyle = '#2ac1bc'
-    ctx.lineWidth = 2
-    ctx.font = '700 12px Noto Sans KR'
+    ctx.lineWidth = 4
+    ctx.font = '700 24px Noto Sans KR'
 
     // 선 그리기
     ctx.beginPath()
     data.forEach((datum, idx) => {
-      const xPoint = gridWidth * idx * 2
+      const xPoint = gridWidth * idx * 2 + X_PADDING
       const yPoint = CHART_HEIGHT - (datum / maxDataValue) * CHART_HEIGHT
 
       if (!idx) {
@@ -126,7 +126,7 @@ export default class LineChart extends Component {
     // 가격, 점 그리기
     data.forEach((datum, idx) => {
       ctx.beginPath()
-      const xPoint = gridWidth * idx * 2
+      const xPoint = gridWidth * idx * 2 + X_PADDING
       const yPoint = CHART_HEIGHT - (datum / maxDataValue) * CHART_HEIGHT
 
       if (idx === data.length - 1) {
@@ -138,7 +138,7 @@ export default class LineChart extends Component {
       ctx.fillText(priceToString(datum), xPoint, yPoint - 12)
 
       ctx.fillStyle = '#2ac1bc'
-      ctx.arc(xPoint, yPoint, 4, 0, 2 * Math.PI)
+      ctx.arc(xPoint, yPoint, 8, 0, 2 * Math.PI)
       ctx.fill()
     })
   }

--- a/src/frontend/components/LineChart/lineChart.scss
+++ b/src/frontend/components/LineChart/lineChart.scss
@@ -3,7 +3,7 @@
 
 .line-board {
   margin-top: 16px;
-  padding: 35px 42px 32px 42px;
+  padding: 32px 0;
 
   width: 848px;
 
@@ -16,5 +16,11 @@
 
 .line-chart-title {
   @include body-large-text;
+  margin-left: 42px;
   margin-bottom: 32px;
+}
+
+.line-chart {
+  width: 800px;
+  height: 340px;
 }


### PR DESCRIPTION
## 📑 개요

라인 차트 화질 개선

## 📎 관련 이슈

close #79

## 💬 작업 내용

canvas의 width, height를 2배로 늘리고 css로 width와 height를 원래 크기로 맞추어 선명도를 높였습니다.

## 🖼 스크린샷(추가사항)

### 개선 전

<img width="830" alt="스크린샷 2022-07-28 오후 12 52 34" src="https://user-images.githubusercontent.com/60956392/181418979-32585875-689a-440a-b0fb-ae70e52cabcc.png">

### 개선 후

<img width="818" alt="스크린샷 2022-07-28 오후 1 14 47" src="https://user-images.githubusercontent.com/60956392/181418965-ba49ac83-2002-447d-b1de-aacd5e0a2f78.png">

## 🚧 PR 특이 사항

주암님께서 알려주셨습니다