### PR TITLE
Feat/40/create payment

### DIFF
--- a/src/frontend/api/payment.js
+++ b/src/frontend/api/payment.js
@@ -1,0 +1,8 @@
+import fetcher from '../utils/fetcher.js'
+
+const getPaymentList = async () => {
+  const { data } = await fetcher.get('/payment')
+  return data
+}
+
+export { getPaymentList }

--- a/src/frontend/api/payment.js
+++ b/src/frontend/api/payment.js
@@ -5,4 +5,9 @@ const getPaymentList = async () => {
   return data
 }
 
-export { getPaymentList }
+const createPayment = async (body) => {
+  const { data } = await fetcher.post('/payment', body)
+  return data
+}
+
+export { getPaymentList, createPayment }

--- a/src/frontend/assets/row-arrow.svg
+++ b/src/frontend/assets/row-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 6.5L8 10.5L12 6.5" stroke="#8D9393" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/frontend/components/Modal/AddPaymentModal.js
+++ b/src/frontend/components/Modal/AddPaymentModal.js
@@ -8,10 +8,6 @@ export default class AddPaymentModal extends Component {
     super(props)
   }
 
-  addPayment(payment) {
-    console.log('ADD PAYMENT' + payment)
-  }
-
   handleClickBackground() {
     closeModal(this)
   }
@@ -26,8 +22,8 @@ export default class AddPaymentModal extends Component {
       return
     }
 
-    this.addPayment($paymentInput.value)
-    this.setModalOpen(false)
+    this.props.addPayment($paymentInput.value)
+    closeModal(this)
   }
 
   handleInputPayment(e) {

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -144,10 +144,6 @@ export default class PaymentBar extends Component {
   checkFormButton() {
     const check = Object.values(this.state).every((state) => state !== '' && state !== 0)
 
-    this.setState({
-      disabled: !check,
-    })
-
     if (check) {
       this.querySelector('.form-button').classList.add('submit')
     } else {

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -15,15 +15,15 @@ export default class PaymentBar extends Component {
       paymentDate: todayDate(),
       category: '',
       title: '',
+      paymentName: '',
       payment_id: 0,
       price: 0,
       option: false,
-      disabled: true,
     }
   }
 
   template() {
-    const { paymentDate, category, title, payment_id, price, option, disabled } = this.state
+    const { paymentDate, category, title, payment_id, paymentName, price, option } = this.state
 
     return /*html*/ `
     <div class='paymentbar-container'>
@@ -53,7 +53,7 @@ export default class PaymentBar extends Component {
     
                  <div class="form-element-dropdown">
                     <div class='select-dropdown' id='payment-select'>
-                      ${payment_id ? payment_id : '선택하세요'}
+                      ${paymentName ? paymentName : '선택하세요'}
                       ${rowArrow}
                     </div>
                     <div class="category-dropdown-payment"></div>
@@ -121,6 +121,16 @@ export default class PaymentBar extends Component {
       price: tmpPrice,
     }
     createTransactionAPI(data)
+
+    this.setState({
+      paymentDate: todayDate(),
+      category: '',
+      title: '',
+      paymentName: '',
+      payment_id: 0,
+      price: 0,
+      option: false,
+    })
   }
 
   handleClickCategorySelect(e) {
@@ -187,9 +197,10 @@ export default class PaymentBar extends Component {
   }
 
   // 결제수단 입력 폼
-  handleInputPaymentId(selectedItem) {
+  handleInputPaymentId(payment_id, paymentName) {
     this.setState({
-      payment_id: 2,
+      payment_id,
+      paymentName,
     })
     this.checkFormButton()
   }

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -193,9 +193,9 @@ export default class PaymentBar extends Component {
   }
 
   // 결제수단 입력 폼
-  handleInputPaymentId(payment_id, paymentName) {
+  handleInputPaymentId(paymentId, paymentName) {
     this.setState({
-      payment_id,
+      payment_id: paymentId,
       paymentName,
     })
     this.checkFormButton()

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -3,6 +3,7 @@ import { CATEGORY } from '../../utils/constants.js'
 import './paymentbar.scss'
 import minus from '../../assets/minus.svg'
 import plus from '../../assets/plus.svg'
+import rowArrow from '../../assets/row-arrow.svg'
 import CategoryDropdown from '../CategoryDropdown/CategoryDropdown.js'
 import PaymentDropdown from '../PaymentDropdown/PaymentDropdown.js'
 import { priceToString, todayDate } from '../../utils/stringUtil.js'
@@ -35,9 +36,10 @@ export default class PaymentBar extends Component {
                 <span class='form-element-title'>분류</span>
             
                 <div class="form-element-dropdown">
-                    <div class="select-dropdown" id='category-select';>${
-                      category ? CATEGORY[category] : '선택하세요'
-                    }</div>
+                    <div class="select-dropdown" id='category-select'>
+                      ${category ? CATEGORY[category] : '선택하세요'}
+                      ${rowArrow}
+                    </div>
                     <div class="category-dropdown-category"></div>
                 </div>
 
@@ -50,9 +52,10 @@ export default class PaymentBar extends Component {
                 <span class='form-element-title'>결제수단</span>
     
                  <div class="form-element-dropdown">
-                    <div class='select-dropdown' id='payment-select'>${
-                      payment_id ? payment_id : '선택하세요'
-                    }</div>
+                    <div class='select-dropdown' id='payment-select'>
+                      ${payment_id ? payment_id : '선택하세요'}
+                      ${rowArrow}
+                    </div>
                     <div class="category-dropdown-payment"></div>
                 </div>
             </div>

--- a/src/frontend/components/PaymentBar/paymentbar.scss
+++ b/src/frontend/components/PaymentBar/paymentbar.scss
@@ -140,4 +140,9 @@
   white-space: nowrap;
   cursor: pointer;
   line-height: 26px;
+
+  svg {
+    height: 16px;
+    width: 16px;
+  }
 }

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -1,4 +1,5 @@
 import { Component } from '../../core/component.js'
+import { getPaymentList } from '../../api/payment.js'
 import './paymentdropdown.scss'
 import removeIcon from '../../assets/removeIcon.svg'
 
@@ -6,11 +7,16 @@ export default class PaymentDropdown extends Component {
   constructor(props) {
     super(props)
   }
-  initState() {
-    // 기능 개발 시, 결제수단 API에서 받아온 데이터로 대체하기
+  async initState() {
     this.state = {
-      payment: ['신한은행', '국민은행', '현금', '비씨카드'],
+      payment: [],
     }
+
+    const data = await getPaymentList()
+
+    this.setState({
+      payment: data,
+    })
   }
 
   template() {
@@ -19,11 +25,12 @@ export default class PaymentDropdown extends Component {
       <ul class="dropdown-ul payment-select">
         ${payment
           .map(
-            (item) => ` <li class="dropdown-li" id=${item}>${item} 
+            ({ id, name }) => ` <li class="dropdown-li" id=${id}>${name} 
           <button>${removeIcon}</button>
           </li>`,
           )
           .join('')}
+          <li class='dropdown-li create-li'>추가하기</li>
       </ul>
     `
   }
@@ -35,8 +42,14 @@ export default class PaymentDropdown extends Component {
 
   handleClickCategoryItem(e) {
     const $item = e.target.closest('.dropdown-li')
-    const paymentItem = $item.id
-    this.props.handleInputPaymentId(paymentItem)
+
+    if ($item.classList.contains('create-li')) {
+      // 모달 호출
+    } else {
+      const payment_id = $item.id
+      const paymentName = $item.innerText
+      this.props.handleInputPaymentId(payment_id, paymentName)
+    }
   }
 }
 

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -49,9 +49,9 @@ export default class PaymentDropdown extends Component {
     if ($item.classList.contains('create-li')) {
       openModal(new AddPaymentModal({ addPayment: this.addPayment.bind(this) }))
     } else {
-      const payment_id = $item.id
+      const paymentId = $item.id
       const paymentName = $item.innerText
-      this.props.handleInputPaymentId(payment_id, paymentName)
+      this.props.handleInputPaymentId(paymentId, paymentName)
     }
   }
 

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -2,6 +2,9 @@ import { Component } from '../../core/component.js'
 import { getPaymentList } from '../../api/payment.js'
 import './paymentdropdown.scss'
 import removeIcon from '../../assets/removeIcon.svg'
+import AddPaymentModal from '../Modal/AddPaymentModal.js'
+import { openModal } from '../../utils/modal.js'
+import { createPayment } from '../../api/payment.js'
 
 export default class PaymentDropdown extends Component {
   constructor(props) {
@@ -44,11 +47,23 @@ export default class PaymentDropdown extends Component {
     const $item = e.target.closest('.dropdown-li')
 
     if ($item.classList.contains('create-li')) {
-      // 모달 호출
+      openModal(new AddPaymentModal({ addPayment: this.addPayment.bind(this) }))
     } else {
       const payment_id = $item.id
       const paymentName = $item.innerText
       this.props.handleInputPaymentId(payment_id, paymentName)
+    }
+  }
+
+  async addPayment(paymentName) {
+    try {
+      const data = await createPayment({ name: paymentName })
+
+      this.setState({
+        payment: [...this.state.payment, { id: data, name: paymentName }],
+      })
+    } catch (e) {
+      console.error(e)
     }
   }
 }


### PR DESCRIPTION
## 📑 개요

결제수단 추가 로직

## 📎 관련 이슈

close #40 

## 💬 작업 내용

- 결제수단 추가 시 모달창 띄우기
- 모달창에서 카드 추가 시, API 요청으로 카드 생성
- 카드 생성시 정상적으로 추가되어 서버에서 반환값이 오면 낙관적업데이트로 화면에 바로 카드 내역 추가

## 🖼 스크린샷(추가사항)

![스크린샷 2022-07-28 오후 2 07 35](https://user-images.githubusercontent.com/52727782/181425115-9af78423-f7a1-4aa2-aeee-f3378391db91.png)

![스크린샷 2022-07-28 오후 2 06 58](https://user-images.githubusercontent.com/52727782/181425041-c44b6229-67b0-4c12-8a01-ac735efb3044.png)
