### PR TITLE
Feat/39/delete payment

### DIFF
--- a/src/frontend/api/payment.js
+++ b/src/frontend/api/payment.js
@@ -10,4 +10,8 @@ const createPayment = async (body) => {
   return data
 }
 
-export { getPaymentList, createPayment }
+const deletePaymentAPI = async (id) => {
+  await fetcher.delete(`/payment/${id}`)
+}
+
+export { getPaymentList, createPayment, deletePaymentAPI }

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -4,7 +4,7 @@ import './paymentdropdown.scss'
 import removeIcon from '../../assets/removeIcon.svg'
 import AddPaymentModal from '../Modal/AddPaymentModal.js'
 import { openModal } from '../../utils/modal.js'
-import { createPayment } from '../../api/payment.js'
+import { createPayment, deletePaymentAPI } from '../../api/payment.js'
 
 export default class PaymentDropdown extends Component {
   constructor(props) {
@@ -29,7 +29,7 @@ export default class PaymentDropdown extends Component {
         ${payment
           .map(
             ({ id, name }) => ` <li class="dropdown-li" id=${id}>${name} 
-          <button>${removeIcon}</button>
+          <button class='payment-remove-button'>${removeIcon}</button>
           </li>`,
           )
           .join('')}
@@ -46,9 +46,19 @@ export default class PaymentDropdown extends Component {
   handleClickCategoryItem(e) {
     const $item = e.target.closest('.dropdown-li')
 
+    // 삭제 버튼 클릭한 경우
+    const $remove = e.target.closest('.payment-remove-button')
+    if ($remove) {
+      this.deletePayment($item.id)
+      return
+    }
+
+    //추가하기 버튼 클릭한 경우
     if ($item.classList.contains('create-li')) {
       openModal(new AddPaymentModal({ addPayment: this.addPayment.bind(this) }))
-    } else {
+    }
+    // li를 클릭한 경우
+    else {
       const paymentId = $item.id
       const paymentName = $item.innerText
       this.props.handleInputPaymentId(paymentId, paymentName)
@@ -61,6 +71,18 @@ export default class PaymentDropdown extends Component {
 
       this.setState({
         payment: [...this.state.payment, { id: data, name: paymentName }],
+      })
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async deletePayment(id) {
+    try {
+      await deletePaymentAPI(id)
+      const filterPayment = this.state.payment.filter((payment) => payment.id !== id)
+      this.setState({
+        payment: [...filterPayment],
       })
     } catch (e) {
       console.error(e)

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -70,7 +70,7 @@ export default class PaymentDropdown extends Component {
       const data = await createPayment({ name: paymentName })
 
       this.setState({
-        payment: [...this.state.payment, { id: data, name: paymentName }],
+        payment: [...this.state.payment, { id: data.id, name: paymentName }],
       })
     } catch (e) {
       console.error(e)
@@ -80,7 +80,7 @@ export default class PaymentDropdown extends Component {
   async deletePayment(id) {
     try {
       await deletePaymentAPI(id)
-      const filterPayment = this.state.payment.filter((payment) => payment.id !== id)
+      const filterPayment = this.state.payment.filter((payment) => payment.id !== Number(id))
       this.setState({
         payment: [...filterPayment],
       })

--- a/src/frontend/utils/fetcher.js
+++ b/src/frontend/utils/fetcher.js
@@ -33,7 +33,7 @@ const fetcher = {
   get: (url) => fetchWrapper(url, HTTP_METHOD.GET),
   post: (url, body) => fetchWrapper(url, HTTP_METHOD.POST, body),
   put: (url, body) => fetchWrapper(url, HTTP_METHOD.PUT, body),
-  delete: (url, body) => fetchWrapper(url, HTTP_METHOD.DELETE),
+  delete: (url) => fetchWrapper(url, HTTP_METHOD.DELETE),
 }
 
 export default fetcher


### PR DESCRIPTION
## 📑 개요

결제 수단 삭제 로직 구현

## 📎 관련 이슈

close #39 

## 💬 작업 내용

- 결제 수단 삭제 아이콘 클릭 시, 삭제 API 요청
- 낙관적 업데이트로 새로고침없이 데이터 삭제된 것 처럼 구현

## 🖼 스크린샷(추가사항)
![스크린샷 2022-07-28 오후 3 25 17](https://user-images.githubusercontent.com/52727782/181435464-e478a0bc-65e3-4c55-a419-f821d107ac0b.png)

![스크린샷 2022-07-28 오후 3 33 11](https://user-images.githubusercontent.com/52727782/181436780-d0d88995-ff36-419c-b8e3-1d1b1ebe8f5a.png)

## 🚧 PR 특이 사항

낙관적 업데이트로 새로고침없이 데이터 삭제된 것 처럼 구현
