### PR TITLE
Feat/26/transaction update api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "webpack-cli": "^4.10.0",
         "webpack-dev-middleware": "^5.3.3",
         "webpack-merge": "^5.8.0",
-        "zihorm": "^1.0.3-beta"
+        "zihorm": "^1.0.3-beta-3"
       },
       "devDependencies": {
         "@babel/cli": "^7.18.6",
@@ -5476,9 +5476,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zihorm": {
-      "version": "1.0.3-beta",
-      "resolved": "https://registry.npmjs.org/zihorm/-/zihorm-1.0.3-beta.tgz",
-      "integrity": "sha512-gW5DMGHjIuswLud+himK56Awa0sa3IEqhQuSXFQ4BZrrzEhrUxtDN61mIvOzwrXabUVViGHVOm2sT89/Ojh6jQ==",
+      "version": "1.0.3-beta-3",
+      "resolved": "https://registry.npmjs.org/zihorm/-/zihorm-1.0.3-beta-3.tgz",
+      "integrity": "sha512-+UCy0zKo1JbhapLDT50ZKIWrffVKUp1PgYKqeatTXhBwGsH5plyB0lqUH9tqXV9vZ+CyfppyQmNyTbTAUnR4Dg==",
       "dependencies": {
         "mysql2": "^2.3.3"
       }
@@ -9427,9 +9427,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zihorm": {
-      "version": "1.0.3-beta",
-      "resolved": "https://registry.npmjs.org/zihorm/-/zihorm-1.0.3-beta.tgz",
-      "integrity": "sha512-gW5DMGHjIuswLud+himK56Awa0sa3IEqhQuSXFQ4BZrrzEhrUxtDN61mIvOzwrXabUVViGHVOm2sT89/Ojh6jQ==",
+      "version": "1.0.3-beta-3",
+      "resolved": "https://registry.npmjs.org/zihorm/-/zihorm-1.0.3-beta-3.tgz",
+      "integrity": "sha512-+UCy0zKo1JbhapLDT50ZKIWrffVKUp1PgYKqeatTXhBwGsH5plyB0lqUH9tqXV9vZ+CyfppyQmNyTbTAUnR4Dg==",
       "requires": {
         "mysql2": "^2.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-middleware": "^5.3.3",
     "webpack-merge": "^5.8.0",
-    "zihorm": "^1.0.3-beta"
+    "zihorm": "^1.0.3-beta-3"
   }
 }

--- a/src/backend/controllers/transactionHistory.js
+++ b/src/backend/controllers/transactionHistory.js
@@ -41,10 +41,17 @@ const createTransaction = async (req, res) => {
   res.status(200).send({ data })
 }
 
+const updateTransaction = async (req, res) => {
+  const { id } = req.params
+  await TransactionService.updateTransaction(id, req.body)
+  res.status(200).send()
+}
+
 export {
   getTransactionHistory,
   getExpenseTransactionHistory,
   getCategoryExpenseDetailTransactionList,
   getSixMonthCategoryExpenseTransactionHistory,
   createTransaction,
+  updateTransaction,
 }

--- a/src/backend/routes/transactionHistory.js
+++ b/src/backend/routes/transactionHistory.js
@@ -5,6 +5,7 @@ import {
   getTransactionHistory,
   getSixMonthCategoryExpenseTransactionHistory,
   createTransaction,
+  updateTransaction,
 } from '../controllers/transactionHistory.js'
 
 const transactionRouter = express.Router()
@@ -15,5 +16,6 @@ transactionRouter.get('/category/six-month', getSixMonthCategoryExpenseTransacti
 transactionRouter.get('/category/detail', getCategoryExpenseDetailTransactionList)
 
 transactionRouter.post('/', createTransaction)
+transactionRouter.put('/:id', updateTransaction)
 
 export { transactionRouter }

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -124,15 +124,7 @@ const TransactionService = {
     return response
   },
   async updateTransaction(id, data) {
-    const { paymentDate, category, title, payment_id, price } = data
-    const body = {}
-    if (paymentDate) body.paymentDate = paymentDate
-    if (category) body.category = category
-    if (title) body.title = title
-    if (payment_id) body.payment_id = payment_id
-    if (price) body.price = price
-
-    await TransactionHistory.update(body, {
+    await TransactionHistory.update(data, {
       where: {
         id,
       },

--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -5,7 +5,7 @@ import { getBeforeSixMonthDate, fillZero, getMonthsObject } from '../utils/dateU
 
 const TransactionService = {
   // 메인, 달력 페이지를 위한 get 요청, 수입,지출 거래 내역
-  getTransactionList: async (year, month) => {
+  async getTransactionList(year, month) {
     const response = await TransactionHistory.findAll({
       attributes: [
         'transaction_history.id',
@@ -35,7 +35,7 @@ const TransactionService = {
   },
 
   // 도넛차트를 위한 get 요청, 매달 카테고리별 지출 내역
-  getExpenseTransactionList: async (year, month) => {
+  async getExpenseTransactionList(year, month) {
     const response = await TransactionHistory.findAll({
       attributes: ['category', 'ABS(SUM(price)) as price'],
       where: {
@@ -53,7 +53,7 @@ const TransactionService = {
   },
 
   // 카테고리별 상세 지출 내역 가져오기 위한 get 요청
-  getCategoryExpenseTransactionList: async (year, month, category) => {
+  async getCategoryExpenseTransactionList(year, month, category) {
     const response = await TransactionHistory.findAll({
       attributes: [
         'transaction_history.id',
@@ -84,7 +84,7 @@ const TransactionService = {
   },
 
   // 라인차트를 위한 get 요청, 최근 6개월 데이터
-  getSixMonthCategoryExpenseTransactionList: async (year, month, category) => {
+  async getSixMonthCategoryExpenseTransactionList(year, month, category) {
     const [startYear, startMonth] = getBeforeSixMonthDate(year, month)
 
     const endDate = new Date(year, month, 0).getDate()
@@ -111,7 +111,7 @@ const TransactionService = {
     return monthsData
   },
 
-  createTransaction: async (data) => {
+  async createTransaction(data) {
     const { paymentDate, category, title, payment_id, price } = data
     const response = await TransactionHistory.create({
       payment_date: paymentDate,
@@ -122,6 +122,21 @@ const TransactionService = {
     })
 
     return response
+  },
+  async updateTransaction(id, data) {
+    const { paymentDate, category, title, payment_id, price } = data
+    const body = {}
+    if (paymentDate) body.paymentDate = paymentDate
+    if (category) body.category = category
+    if (title) body.title = title
+    if (payment_id) body.payment_id = payment_id
+    if (price) body.price = price
+
+    await TransactionHistory.update(body, {
+      where: {
+        id,
+      },
+    })
   },
 }
 


### PR DESCRIPTION
## 📑 개요

거래내역 수정 API 구현

## 📎 관련 이슈

close #26

## 💬 작업 내용

payment_date, category, title, payment_id, price 수정가능한 PUT API를 구현했습니다.

추가적으로 크롱이 피드백 주신 부분도 반영했습니다.

```
    const obj = {
      post: () => {
          ..
      }
    }    
    const obj = {
       post() {
      }
    }
```

## 🚧 PR 특이 사항
