### PR TITLE
Feat/38/transaction update modal

### DIFF
--- a/src/backend/services/transactionHistory.js
+++ b/src/backend/services/transactionHistory.js
@@ -13,6 +13,7 @@ const TransactionService = {
         'category',
         'title',
         'price',
+        'payment_id',
         'name as payment',
         'is_deleted',
       ],

--- a/src/frontend/api/transactionHistory.js
+++ b/src/frontend/api/transactionHistory.js
@@ -26,9 +26,14 @@ const createTransactionAPI = async (body) => {
   const { data } = await fetcher.post('/transaction', body)
 }
 
+const updateTransactionAPI = async (id, body) => {
+  await fetcher.put(`/transaction/${id}`, body)
+}
+
 export {
   getTransactionHistoryList,
   getExpenseTransactionHistoryList,
   getCategorySixMonthTrend,
   createTransactionAPI,
+  updateTransactionAPI,
 }

--- a/src/frontend/components/CategoryDropdown/CategoryDropdown.js
+++ b/src/frontend/components/CategoryDropdown/CategoryDropdown.js
@@ -3,13 +3,10 @@ import { CATEGORY_INCOME, CATEGORY_EXPENSE } from '../../utils/constants.js'
 import './categorydropdown.scss'
 
 export default class CategoryDropdown extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   template() {
+    const { isUpdate } = this.props
     return /*html*/ `
-      <ul class="dropdown-ul category-select">
+      <ul class="dropdown-ul category-select ${isUpdate ? 'update' : ''}">
         <div class="dropdown-title expense">지출</div>
         ${Object.keys(CATEGORY_EXPENSE)
           .map((key) => ` <li class="dropdown-li false" id=${key}>${CATEGORY_EXPENSE[key]}</li>`)

--- a/src/frontend/components/CategoryDropdown/categorydropdown.scss
+++ b/src/frontend/components/CategoryDropdown/categorydropdown.scss
@@ -2,6 +2,8 @@
 @import '../../styles/text-style.scss';
 
 .dropdown-ul {
+  z-index: 1002;
+
   overflow: hidden;
 
   position: absolute;
@@ -23,6 +25,13 @@
 
   &.active {
     display: block;
+  }
+
+  &.update {
+    left: 0;
+    width: 100%;
+    max-height: 400px;
+    overflow-y: auto;
   }
 }
 

--- a/src/frontend/components/CategoryDropdown/categorydropdown.scss
+++ b/src/frontend/components/CategoryDropdown/categorydropdown.scss
@@ -2,16 +2,17 @@
 @import '../../styles/text-style.scss';
 
 .dropdown-ul {
-  z-index: 1002;
+  z-index: 1000;
 
   overflow: hidden;
+  overflow-y: auto;
 
   position: absolute;
   top: 48px;
   left: -24px;
 
   width: 122px;
-
+  max-height: 630px;
   display: none;
 
   background-color: $color-off-white;
@@ -53,6 +54,8 @@
 
 .dropdown-li {
   @include body-regular-text;
+
+  cursor: pointer;
 
   padding: 16px 24px;
 

--- a/src/frontend/components/DateTransactionList/DateTransactionList.js
+++ b/src/frontend/components/DateTransactionList/DateTransactionList.js
@@ -46,6 +46,7 @@ export default class DateTransactionList extends Component {
           id: transactionItem.id,
           category: transactionItem.category,
           title: transactionItem.title,
+          paymentId: transactionItem.payment_id,
           payment: transactionItem.payment,
           price: transactionItem.price,
           isEditable: this.props.isEditable ?? false,

--- a/src/frontend/components/DateTransactionList/DateTransactionList.js
+++ b/src/frontend/components/DateTransactionList/DateTransactionList.js
@@ -42,6 +42,8 @@ export default class DateTransactionList extends Component {
     transactionList.forEach((transactionItem) => {
       $transactionList.appendChild(
         new TransactionItem({
+          paymentDate: transactionItem.payment_date,
+          id: transactionItem.id,
           category: transactionItem.category,
           title: transactionItem.title,
           payment: transactionItem.payment,

--- a/src/frontend/components/DateTransactionList/DateTransactionList.js
+++ b/src/frontend/components/DateTransactionList/DateTransactionList.js
@@ -37,10 +37,10 @@ export default class DateTransactionList extends Component {
 
   setComponent() {
     const { transactionList } = this.props
-    const $trnasactionList = this.querySelector(`.date-transaction-list`)
+    const $transactionList = this.querySelector(`.date-transaction-list`)
 
     transactionList.forEach((transactionItem) => {
-      $trnasactionList.appendChild(
+      $transactionList.appendChild(
         new TransactionItem({
           category: transactionItem.category,
           title: transactionItem.title,

--- a/src/frontend/components/DateTransactionList/DateTransactionList.js
+++ b/src/frontend/components/DateTransactionList/DateTransactionList.js
@@ -48,6 +48,7 @@ export default class DateTransactionList extends Component {
           title: transactionItem.title,
           payment: transactionItem.payment,
           price: transactionItem.price,
+          isEditable: this.props.isEditable ?? false,
         }),
       )
     })

--- a/src/frontend/components/Modal/RemovePaymentModal.js
+++ b/src/frontend/components/Modal/RemovePaymentModal.js
@@ -3,8 +3,9 @@ import { closeModal } from '../../utils/modal.js'
 import './paymentModal.scss'
 
 export default class RemovePaymentModal extends Component {
-  removePayment() {
-    console.log('REMOVE PAYMENT')
+  async removePayment() {
+    const { id, deletePayment } = this.props
+    await deletePayment(id)
   }
 
   handleClickBackground() {
@@ -31,7 +32,7 @@ export default class RemovePaymentModal extends Component {
   }
 
   template() {
-    // const { selectedPayment } = this.props
+    const { name } = this.props
 
     return /*html*/ `
       <div class="modal-wrapper">
@@ -39,7 +40,7 @@ export default class RemovePaymentModal extends Component {
         <div class="modal-content">
           <div class="payment-modal-wrapper">
             <p class="payment-modal-title">해당 결제수단을 삭제하시겠습니까?</p>
-            <p class="payment-modal-input-text">props 자리</p>
+            <p class="payment-modal-input-text">${name}</p>
 
             <div class="payment-modal-button-wrapper">
               <button class="payment-modal-cancel-button">취소</button>

--- a/src/frontend/components/Modal/UpdateTransactionModal.js
+++ b/src/frontend/components/Modal/UpdateTransactionModal.js
@@ -1,0 +1,88 @@
+import { Component } from '../../core/component.js'
+import { closeModal } from '../../utils/modal.js'
+
+import './updateTransactionModal.scss'
+import IconPlus from '../../assets/plus.svg'
+import IconMinus from '../../assets/minus.svg'
+import { CATEGORY } from '../../utils/constants.js'
+
+export default class UpdateTransactionModal extends Component {
+  initState() {
+    this.state = {
+      option: false,
+    }
+  }
+
+  handleClickBackground() {
+    closeModal(this)
+  }
+
+  handleClickCancelButton() {
+    closeModal(this)
+  }
+
+  handleClickUpdateButton() {
+    this.removePayment()
+    closeModal(this)
+  }
+
+  setEvent() {
+    const $modalBackground = this.querySelector('.modal-background')
+    const $cancelButton = this.querySelector('.transaction-modal-cancel-button')
+    const $updateButton = this.querySelector('.transaction-modal-update-button')
+
+    $modalBackground.addEventListener('click', this.handleClickBackground.bind(this))
+    $cancelButton.addEventListener('click', this.handleClickCancelButton.bind(this))
+    $updateButton.addEventListener('click', this.handleClickUpdateButton.bind(this))
+  }
+
+  template() {
+    const { paymentDate, title, category, payment, price } = this.props
+    const { option } = this.state
+
+    return /*html*/ `
+      <div class="modal-wrapper">
+        <div class="modal-background"></div>
+        <div class="modal-content">
+          <div class="transaction-modal-wrapper">
+           <div class="transaction-form">
+            <label>일자</label>
+            <input class="transaction-form-input" placeholder="입력하세요" value="${paymentDate}" />
+            <label>분류</label>
+            <div class="transaction-form-dropdown">
+              <div class="select-dropdown" id='category-select'>
+              ${category ? CATEGORY[category] : '선택하세요'}
+              </div>
+              <div class="category-dropdown-category"></div>
+            </div>
+            <label>내용</label>
+            <input class="transaction-form-input" placeholder="입력하세요"  value="${title}" />
+            <label>결제수단</label>
+            <div class="transaction-form-dropdown">
+              <div class='select-dropdown' id='payment-select'>
+              ${payment ? payment : '선택하세요'}
+              </div>
+              <div class="category-dropdown-payment"></div>
+            </div>
+            <label>금액</label>
+            <div class="transaction-form-price">
+              ${option ? IconPlus : IconMinus}
+              <input class='transaction-form-input' id='price' placeholder='입력하세요' value=${Math.abs(
+                price,
+              )}>
+              <span>원</span>
+            </div>
+           </div>
+
+            <div class="transaction-modal-button-wrapper">
+              <button class="transaction-modal-cancel-button">취소</button>
+              <button class="transaction-modal-update-button active">수정</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `
+  }
+}
+
+customElements.define('updatetransaction-modal', UpdateTransactionModal)

--- a/src/frontend/components/Modal/UpdateTransactionModal.js
+++ b/src/frontend/components/Modal/UpdateTransactionModal.js
@@ -5,12 +5,34 @@ import './updateTransactionModal.scss'
 import IconPlus from '../../assets/plus.svg'
 import IconMinus from '../../assets/minus.svg'
 import { CATEGORY } from '../../utils/constants.js'
+import { priceToString, replaceDateDash, replacePriceComma } from '../../utils/stringUtil.js'
 
 export default class UpdateTransactionModal extends Component {
   initState() {
+    const { category, payment, price } = this.props
+
     this.state = {
-      option: false,
+      category,
+      payment,
+      option: price > 0,
     }
+  }
+
+  checkInputValidation() {
+    const { category, payment } = this.state
+    const $dateInput = this.querySelector('#transaction-date-input')
+    const $priceInput = this.querySelector('#transaction-price-input')
+    const $titleInput = this.querySelector('#transaction-title-input')
+
+    const $updateButton = this.querySelector('.transaction-modal-update-button')
+
+    if (!category || !payment || !$dateInput.value || !$priceInput.value || !$titleInput.value) {
+      $updateButton.classList.remove('active')
+      return false
+    }
+
+    $updateButton.classList.add('active')
+    return true
   }
 
   handleClickBackground() {
@@ -22,24 +44,55 @@ export default class UpdateTransactionModal extends Component {
   }
 
   handleClickUpdateButton() {
-    this.removePayment()
+    if (!this.checkInputValidation()) return
+
     closeModal(this)
+  }
+
+  handleInputDate(e) {
+    const { value } = e.target
+
+    e.target.value = replaceDateDash(value)
+    this.checkInputValidation()
+  }
+
+  handleInputPrice(e) {
+    const { value } = e.target
+
+    const pureNumber = value.replace(/[^0-9]/g, '')
+
+    e.target.value = priceToString(pureNumber)
+
+    this.checkInputValidation()
+  }
+
+  handleInputTitle(e) {
+    const { value } = e.target
+
+    this.checkInputValidation()
   }
 
   setEvent() {
     const $modalBackground = this.querySelector('.modal-background')
     const $cancelButton = this.querySelector('.transaction-modal-cancel-button')
     const $updateButton = this.querySelector('.transaction-modal-update-button')
+    const $dateInput = this.querySelector('#transaction-date-input')
+    const $priceInput = this.querySelector('#transaction-price-input')
+    const $titleInput = this.querySelector('#transaction-title-input')
 
     $modalBackground.addEventListener('click', this.handleClickBackground.bind(this))
     $cancelButton.addEventListener('click', this.handleClickCancelButton.bind(this))
     $updateButton.addEventListener('click', this.handleClickUpdateButton.bind(this))
+    $dateInput.addEventListener('input', this.handleInputDate.bind(this))
+    $priceInput.addEventListener('input', this.handleInputPrice.bind(this))
+    $titleInput.addEventListener('input', this.handleInputTitle.bind(this))
   }
 
   template() {
-    const { paymentDate, title, category, payment, price } = this.props
-    const { option } = this.state
+    const { paymentDate, title, price } = this.props
+    const { category, payment, option } = this.state
 
+    const priceString = priceToString(Math.abs(price))
     return /*html*/ `
       <div class="modal-wrapper">
         <div class="modal-background"></div>
@@ -47,7 +100,7 @@ export default class UpdateTransactionModal extends Component {
           <div class="transaction-modal-wrapper">
            <div class="transaction-form">
             <label>일자</label>
-            <input class="transaction-form-input" placeholder="입력하세요" value="${paymentDate}" />
+            <input id="transaction-date-input" class="transaction-form-input" placeholder="입력하세요" maxLength="10" value="${paymentDate}" />
             <label>분류</label>
             <div class="transaction-form-dropdown">
               <div class="select-dropdown" id='category-select'>
@@ -56,7 +109,7 @@ export default class UpdateTransactionModal extends Component {
               <div class="category-dropdown-category"></div>
             </div>
             <label>내용</label>
-            <input class="transaction-form-input" placeholder="입력하세요"  value="${title}" />
+            <input id='transaction-title-input' class="transaction-form-input" placeholder="입력하세요"  value="${title}" />
             <label>결제수단</label>
             <div class="transaction-form-dropdown">
               <div class='select-dropdown' id='payment-select'>
@@ -67,9 +120,7 @@ export default class UpdateTransactionModal extends Component {
             <label>금액</label>
             <div class="transaction-form-price">
               ${option ? IconPlus : IconMinus}
-              <input class='transaction-form-input' id='price' placeholder='입력하세요' value=${Math.abs(
-                price,
-              )}>
+              <input  id='transaction-price-input' class='transaction-form-input' placeholder='입력하세요' value=${priceString}>
               <span>원</span>
             </div>
            </div>

--- a/src/frontend/components/Modal/UpdateTransactionModal.js
+++ b/src/frontend/components/Modal/UpdateTransactionModal.js
@@ -1,38 +1,84 @@
 import { Component } from '../../core/component.js'
+import CategoryDropdown from '../CategoryDropdown/CategoryDropdown.js'
+import PaymentDropdown from '../PaymentDropdown/PaymentDropdown.js'
 import { closeModal } from '../../utils/modal.js'
-
 import './updateTransactionModal.scss'
 import IconPlus from '../../assets/plus.svg'
 import IconMinus from '../../assets/minus.svg'
 import { CATEGORY } from '../../utils/constants.js'
-import { priceToString, replaceDateDash, replacePriceComma } from '../../utils/stringUtil.js'
+import { priceToString, replaceDateDash } from '../../utils/stringUtil.js'
+import { updateTransactionAPI } from '../../api/transactionHistory.js'
+import { getState, setState } from '../../core/observer.js'
+import { transactionListState } from '../../stores/transactionStore.js'
+import { sortTransaction } from '../../utils/transactionUtil.js'
 
 export default class UpdateTransactionModal extends Component {
+  constructor(props) {
+    super(props)
+
+    this.setTransactionList = setState(transactionListState)
+  }
+
   initState() {
-    const { category, payment, price } = this.props
+    const { category, paymentId, payment, price } = this.props
 
     this.state = {
       category,
-      payment,
+      paymentId,
+      paymentName: payment,
       option: price > 0,
     }
   }
 
   checkInputValidation() {
-    const { category, payment } = this.state
+    const { category, paymentId } = this.state
     const $dateInput = this.querySelector('#transaction-date-input')
     const $priceInput = this.querySelector('#transaction-price-input')
     const $titleInput = this.querySelector('#transaction-title-input')
 
     const $updateButton = this.querySelector('.transaction-modal-update-button')
 
-    if (!category || !payment || !$dateInput.value || !$priceInput.value || !$titleInput.value) {
+    if (!category || !paymentId || !$dateInput.value || !$priceInput.value || !$titleInput.value) {
       $updateButton.classList.remove('active')
       return false
     }
 
     $updateButton.classList.add('active')
     return true
+  }
+
+  async updateTransaction() {
+    const $dateInput = this.querySelector('#transaction-date-input')
+    const $priceInput = this.querySelector('#transaction-price-input')
+    const $titleInput = this.querySelector('#transaction-title-input')
+
+    const priceNumber = this.state.option
+      ? Number($priceInput.value.replaceAll(',', ''))
+      : -Number($priceInput.value.replaceAll(',', ''))
+
+    const bodyData = {}
+    if (this.props.category !== this.state.category) bodyData.category = this.state.category
+    if (this.props.paymentId !== this.state.paymentId) bodyData.payment_id = this.state.paymentId
+    if (this.props.paymentDate !== $dateInput.value) bodyData.payment_date = $dateInput.value
+    if (this.props.price !== priceNumber) bodyData.price = priceNumber
+    if (this.props.title !== $titleInput.value) bodyData.title = $titleInput.value
+
+    try {
+      const transactionList = getState(transactionListState)
+      const newTransactionList = transactionList.map((item) => {
+        if (item.id !== this.props.id) return item
+        const newItem = {
+          ...item,
+          ...bodyData,
+        }
+        return newItem
+      })
+      const sortedTransactionList = sortTransaction(newTransactionList)
+      this.setTransactionList(sortedTransactionList)
+      await updateTransactionAPI(this.props.id, bodyData)
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   handleClickBackground() {
@@ -43,9 +89,10 @@ export default class UpdateTransactionModal extends Component {
     closeModal(this)
   }
 
-  handleClickUpdateButton() {
+  async handleClickUpdateButton() {
     if (!this.checkInputValidation()) return
 
+    await this.updateTransaction()
     closeModal(this)
   }
 
@@ -72,6 +119,30 @@ export default class UpdateTransactionModal extends Component {
     this.checkInputValidation()
   }
 
+  handleInputCategory(selectedItem, option) {
+    this.setState({
+      category: selectedItem,
+      option: option,
+    })
+    this.checkInputValidation()
+  }
+
+  handleInputPaymentId(paymentId, paymentName) {
+    this.setState({
+      paymentId,
+      paymentName,
+    })
+    this.checkInputValidation()
+  }
+
+  handleClickCategorySelect(e) {
+    const { id } = e.target
+    if (!id) return
+
+    const $dropdown = this.querySelector(`.${id}`)
+    $dropdown.classList.toggle('active')
+  }
+
   setEvent() {
     const $modalBackground = this.querySelector('.modal-background')
     const $cancelButton = this.querySelector('.transaction-modal-cancel-button')
@@ -79,6 +150,7 @@ export default class UpdateTransactionModal extends Component {
     const $dateInput = this.querySelector('#transaction-date-input')
     const $priceInput = this.querySelector('#transaction-price-input')
     const $titleInput = this.querySelector('#transaction-title-input')
+    const $selectList = this.querySelectorAll('.select-dropdown')
 
     $modalBackground.addEventListener('click', this.handleClickBackground.bind(this))
     $cancelButton.addEventListener('click', this.handleClickCancelButton.bind(this))
@@ -86,11 +158,14 @@ export default class UpdateTransactionModal extends Component {
     $dateInput.addEventListener('input', this.handleInputDate.bind(this))
     $priceInput.addEventListener('input', this.handleInputPrice.bind(this))
     $titleInput.addEventListener('input', this.handleInputTitle.bind(this))
+    $selectList.forEach((item) =>
+      item.addEventListener('click', this.handleClickCategorySelect.bind(this)),
+    )
   }
 
   template() {
     const { paymentDate, title, price } = this.props
-    const { category, payment, option } = this.state
+    const { category, paymentName, option } = this.state
 
     const priceString = priceToString(Math.abs(price))
     return /*html*/ `
@@ -106,16 +181,16 @@ export default class UpdateTransactionModal extends Component {
               <div class="select-dropdown" id='category-select'>
               ${category ? CATEGORY[category] : '선택하세요'}
               </div>
-              <div class="category-dropdown-category"></div>
+              <div class="dropdown-category"></div>
             </div>
             <label>내용</label>
             <input id='transaction-title-input' class="transaction-form-input" placeholder="입력하세요"  value="${title}" />
             <label>결제수단</label>
             <div class="transaction-form-dropdown">
               <div class='select-dropdown' id='payment-select'>
-              ${payment ? payment : '선택하세요'}
+              ${paymentName ? paymentName : '선택하세요'}
               </div>
-              <div class="category-dropdown-payment"></div>
+              <div class="dropdown-payment"></div>
             </div>
             <label>금액</label>
             <div class="transaction-form-price">
@@ -133,6 +208,24 @@ export default class UpdateTransactionModal extends Component {
         </div>
       </div>
     `
+  }
+
+  setComponent() {
+    const $categoryDropdownElement = this.querySelector('.dropdown-category')
+    $categoryDropdownElement.appendChild(
+      new CategoryDropdown({
+        handleInputCategory: this.handleInputCategory.bind(this),
+        isUpdate: true,
+      }),
+    )
+
+    const $paymentDropdownElement = this.querySelector('.dropdown-payment')
+    $paymentDropdownElement.appendChild(
+      new PaymentDropdown({
+        handleInputPaymentId: this.handleInputPaymentId.bind(this),
+        isUpdate: true,
+      }),
+    )
   }
 }
 

--- a/src/frontend/components/Modal/modal.scss
+++ b/src/frontend/components/Modal/modal.scss
@@ -3,7 +3,7 @@
   top: 0;
   left: 0;
 
-  z-index: 1000;
+  z-index: 1001;
 
   width: 100vw;
   height: 100vh;
@@ -18,7 +18,7 @@
   top: 0;
   left: 0;
 
-  z-index: 1000;
+  z-index: 1001;
 
   width: 100%;
   height: 100%;

--- a/src/frontend/components/Modal/paymentModal.scss
+++ b/src/frontend/components/Modal/paymentModal.scss
@@ -17,7 +17,8 @@
   color: $color-title-active;
 }
 
-.payment-modal-input {
+.payment-modal-input,
+.payment-modal-input-text {
   @include body-medium-text;
   margin-top: 24px;
   padding: 10px;
@@ -34,17 +35,10 @@
   }
 }
 
-.payment-modal-input-text {
-  @include body-medium-text;
-  margin-top: 24px;
-  padding: 10px;
-  width: 100%;
-
-  background-color: $color-off-white;
-  color: $color-title-active;
-
-  border: 1px solid $color-line;
-  border-radius: 10px;
+.payment-modal-input {
+  &:placeholder {
+    color: $color-placeholder;
+  }
 }
 
 .payment-modal-button-wrapper {

--- a/src/frontend/components/Modal/updateTransactionModal.scss
+++ b/src/frontend/components/Modal/updateTransactionModal.scss
@@ -1,0 +1,111 @@
+@import '../../styles/color.scss';
+@import '../../styles/text-style.scss';
+@import '../../styles//varibles.scss';
+@import './modal.scss';
+
+.transaction-modal-wrapper {
+  padding: 40px;
+  width: 400px;
+
+  background-color: $color-off-white;
+  border-radius: 10px;
+}
+
+.transaction-modal-button-wrapper {
+  margin-top: 40px;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .transaction-modal-cancel-button {
+    @include body-medium-text;
+    color: $color-label;
+  }
+
+  .transaction-modal-update-button {
+    @include body-medium-text;
+    color: $color-label;
+
+    cursor: default;
+
+    &.active {
+      cursor: pointer;
+      color: $color-primary-300;
+    }
+  }
+}
+
+.transaction-form-input {
+  @include body-medium-text;
+  padding: 10px;
+  width: 100%;
+
+  background-color: $color-background;
+  color: $color-title-active;
+
+  border: 1px solid $color-line;
+  border-radius: 10px;
+
+  &:placeholder {
+    color: $color-placeholder;
+  }
+}
+
+.transaction-form {
+  width: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  label {
+    @include bold-large-text;
+    color: $color-primary-300;
+  }
+}
+
+.transaction-form-price {
+  position: relative;
+
+  .transaction-form-input {
+    padding-right: 24px;
+    text-align: right;
+  }
+
+  svg {
+    position: absolute;
+    top: 12px;
+    left: 8px;
+
+    width: 24px;
+    height: 24px;
+  }
+
+  span {
+    position: absolute;
+    top: 14px;
+    right: 4px;
+  }
+}
+
+.transaction-form-dropdown {
+  @include body-medium-text;
+  padding: 10px;
+  width: 100%;
+
+  background-color: $color-background;
+  color: $color-title-active;
+
+  border: 1px solid $color-line;
+  border-radius: 10px;
+}
+
+.select-dropdown {
+  @include user-select-none;
+  @include body-regular-text;
+
+  white-space: nowrap;
+  cursor: pointer;
+  line-height: 26px;
+}

--- a/src/frontend/components/Modal/updateTransactionModal.scss
+++ b/src/frontend/components/Modal/updateTransactionModal.scss
@@ -91,6 +91,7 @@
 
 .transaction-form-dropdown {
   @include body-medium-text;
+  position: relative;
   padding: 10px;
   width: 100%;
 

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -1,10 +1,11 @@
 import { Component } from '../../core/component.js'
 import { getPaymentList } from '../../api/payment.js'
-import './paymentdropdown.scss'
-import removeIcon from '../../assets/removeIcon.svg'
+import IconRemove from '../../assets/removeIcon.svg'
 import AddPaymentModal from '../Modal/AddPaymentModal.js'
+import RemovePaymentModal from '../Modal/RemovePaymentModal.js'
 import { openModal } from '../../utils/modal.js'
 import { createPayment, deletePaymentAPI } from '../../api/payment.js'
+import './paymentdropdown.scss'
 
 export default class PaymentDropdown extends Component {
   async initState() {
@@ -26,8 +27,8 @@ export default class PaymentDropdown extends Component {
       <ul class="dropdown-ul payment-select  ${isUpdate ? 'update' : ''}">
         ${payment
           .map(
-            ({ id, name }) => ` <li class="dropdown-li" id=${id}>${name} 
-          <button class='payment-remove-button'>${removeIcon}</button>
+            ({ id, name }) => ` <li class="dropdown-li" id=${id} name="${name}">${name} 
+          <button class='payment-remove-button'>${IconRemove}</button>
           </li>`,
           )
           .join('')}
@@ -47,7 +48,13 @@ export default class PaymentDropdown extends Component {
     // 삭제 버튼 클릭한 경우
     const $remove = e.target.closest('.payment-remove-button')
     if ($remove) {
-      this.deletePayment($item.id)
+      openModal(
+        new RemovePaymentModal({
+          id: $item.id,
+          name: $item.getAttribute('name'),
+          deletePayment: this.deletePayment.bind(this),
+        }),
+      )
       return
     }
 
@@ -55,6 +62,7 @@ export default class PaymentDropdown extends Component {
     if ($item.classList.contains('create-li')) {
       openModal(new AddPaymentModal({ addPayment: this.addPayment.bind(this) }))
     }
+
     // li를 클릭한 경우
     else {
       const paymentId = $item.id

--- a/src/frontend/components/PaymentDropdown/PaymentDropdown.js
+++ b/src/frontend/components/PaymentDropdown/PaymentDropdown.js
@@ -7,9 +7,6 @@ import { openModal } from '../../utils/modal.js'
 import { createPayment, deletePaymentAPI } from '../../api/payment.js'
 
 export default class PaymentDropdown extends Component {
-  constructor(props) {
-    super(props)
-  }
   async initState() {
     this.state = {
       payment: [],
@@ -23,9 +20,10 @@ export default class PaymentDropdown extends Component {
   }
 
   template() {
+    const { isUpdate } = this.props
     const { payment } = this.state
     return /*html*/ `
-      <ul class="dropdown-ul payment-select">
+      <ul class="dropdown-ul payment-select  ${isUpdate ? 'update' : ''}">
         ${payment
           .map(
             ({ id, name }) => ` <li class="dropdown-li" id=${id}>${name} 

--- a/src/frontend/components/TransactionItem/TransactionItem.js
+++ b/src/frontend/components/TransactionItem/TransactionItem.js
@@ -22,6 +22,9 @@ export default class TransactionItem extends Component {
   }
 
   setEvent() {
+    const { isEditable } = this.props
+    if (!isEditable) return
+
     const $transactionItem = this.querySelector('.transaction-item')
 
     $transactionItem.addEventListener('click', this.handleClickItem.bind(this))

--- a/src/frontend/components/TransactionItem/TransactionItem.js
+++ b/src/frontend/components/TransactionItem/TransactionItem.js
@@ -1,9 +1,32 @@
 import { Component } from '../../core/component.js'
 import { CATEGORY } from '../../utils/constants.js'
 import { priceToString } from '../../utils/stringUtil.js'
+import { openModal } from '../../utils/modal.js'
+import UpdateTransactionModal from '../Modal/UpdateTransactionModal.js'
 import './transactionItem.scss'
 
 export default class TransactionItem extends Component {
+  handleClickItem() {
+    const { id, category, title, payment, price, paymentDate } = this.props
+
+    openModal(
+      new UpdateTransactionModal({
+        id,
+        title,
+        category,
+        payment,
+        price,
+        paymentDate,
+      }),
+    )
+  }
+
+  setEvent() {
+    const $transactionItem = this.querySelector('.transaction-item')
+
+    $transactionItem.addEventListener('click', this.handleClickItem.bind(this))
+  }
+
   template() {
     const { category, title, payment, price } = this.props
 

--- a/src/frontend/components/TransactionItem/TransactionItem.js
+++ b/src/frontend/components/TransactionItem/TransactionItem.js
@@ -7,13 +7,14 @@ import './transactionItem.scss'
 
 export default class TransactionItem extends Component {
   handleClickItem() {
-    const { id, category, title, payment, price, paymentDate } = this.props
+    const { id, category, title, paymentId, payment, price, paymentDate } = this.props
 
     openModal(
       new UpdateTransactionModal({
         id,
         title,
         category,
+        paymentId,
         payment,
         price,
         paymentDate,

--- a/src/frontend/components/TransactionItem/transactionItem.scss
+++ b/src/frontend/components/TransactionItem/transactionItem.scss
@@ -7,7 +7,9 @@
   display: flex;
   align-items: center;
 
-  transition: background-color 0.2s ease;
+  cursor: pointer;
+
+  transition: background-color 0.3s ease-out;
 
   background-color: $color-off-white;
   &:hover {

--- a/src/frontend/components/TransactionList/TransactionList.js
+++ b/src/frontend/components/TransactionList/TransactionList.js
@@ -75,6 +75,8 @@ export default class TransactionList extends Component {
       $transactionList.appendChild(
         new DateTransactionList({
           transactionList,
+          showTotal: true,
+          isEditable: true,
         }),
       )
     })

--- a/src/frontend/utils/stringUtil.js
+++ b/src/frontend/utils/stringUtil.js
@@ -15,4 +15,11 @@ const fillZero = (number) => {
   return number < 10 ? `0${number}` : number
 }
 
-export { priceToString, fillZero, todayDate }
+const replaceDateDash = (number) => {
+  return number
+    .replace(/[^0-9]/g, '')
+    .replace(/^(\d{0,4})(\d{0,2})(\d{0,2})$/g, '$1-$2-$3')
+    .replace(/\-{1,2}$/g, '')
+}
+
+export { priceToString, fillZero, todayDate, replaceDateDash }


### PR DESCRIPTION
## 📑 개요

거래 내역 업데이트 구현

## 📎 관련 이슈

close #38

## 💬 작업 내용

결제 내역 클릭하면 거래내역 업데이트 모달이 뜹니다.

업데이트 모달에서 input 값에 대한 검증이 이루어집니다.
다 채워진 경우에만 수정이 가능합니다.
기존 값과 달라진 값만 서버로 전송이 됩니다.

+

결제수단 삭제시, 모달이 안뜨고 그냥 삭제되는 버그를 발견해서, 모달에서 이 부분을 처리할 수 있도록 했습니다.

## 🖼 스크린샷(추가사항)

<img width="682" alt="스크린샷 2022-07-28 오후 6 21 05" src="https://user-images.githubusercontent.com/60956392/181470486-39d93095-3500-49e5-97b6-9494a42a1950.png">

## 🚧 PR 특이 사항

이 브랜치에서 백엔드, 거래내역 업데이트 모달, 결제수단 삭제 모달, 드롭다운 많은 부분을 건들여서 수정된 파일이 좀 많습니다..