### PR TITLE
Fix/86/observer

### DIFF
--- a/src/frontend/components/TransactionList/TransactionList.js
+++ b/src/frontend/components/TransactionList/TransactionList.js
@@ -1,5 +1,5 @@
 import { Component } from '../../core/component.js'
-import { getState, subscribe } from '../../core/observer.js'
+import { getState, subscribe, unsubscribeAll } from '../../core/observer.js'
 import { transactionListState } from '../../stores/transactionStore.js'
 import { calculateTransaction, classifyTransactionDataByDate } from '../../utils/transactionUtil.js'
 import DateTransactionList from '../DateTransactionList/DateTransactionList.js'
@@ -11,7 +11,7 @@ import { priceToString } from '../../utils/stringUtil.js'
 export default class TransactionList extends Component {
   constructor(props) {
     super(props)
-
+    unsubscribeAll(transactionListState)
     subscribe(transactionListState, this.render.bind(this))
   }
 

--- a/src/frontend/core/observer.js
+++ b/src/frontend/core/observer.js
@@ -14,7 +14,13 @@ const subscribe = (key, observer) => store[key]._observers.add(observer)
  * @param {function} observer 리렌더링 함수
  */
 const unsubscribe = (key, observer) => {
-  store[key]._observers = [...store[key]._observers].filter((subscriber) => subscriber !== observer)
+  store[key]._observers = new Set(
+    [...store[key]._observers].filter((subscriber) => subscriber !== observer),
+  )
+}
+
+const unsubscribeAll = (key) => {
+  store[key]._observers = new Set()
 }
 
 /**
@@ -54,4 +60,4 @@ const setState = (key) => (newState) => {
   notify(key)
 }
 
-export { subscribe, unsubscribe, initState, getState, setState }
+export { subscribe, unsubscribe, unsubscribeAll, initState, getState, setState }

--- a/src/frontend/pages/CalendarPage/CalendarPage.js
+++ b/src/frontend/pages/CalendarPage/CalendarPage.js
@@ -1,6 +1,6 @@
 import { Component } from '../../core/component.js'
 import { getMonthData } from '../../utils/calendar.js'
-import { getState, subscribe } from '../../core/observer.js'
+import { getState, subscribe, unsubscribeAll } from '../../core/observer.js'
 import { dateState } from '../../stores/dateStore.js'
 import { KR_WEEK } from '../../utils/constants.js'
 import { calculateTransaction, classifyTransactionDataByDate } from '../../utils/transactionUtil.js'
@@ -12,6 +12,7 @@ import './calendarPage.scss'
 export default class CalendarPage extends Component {
   constructor() {
     super()
+    unsubscribeAll(transactionListState)
     subscribe(transactionListState, this.render.bind(this))
   }
   template() {

--- a/src/frontend/pages/ChartPage/ChartPage.js
+++ b/src/frontend/pages/ChartPage/ChartPage.js
@@ -2,7 +2,7 @@ import DateTransactionList from '../../components/DateTransactionList/DateTransa
 import DoughnutChart from '../../components/DoughnutChart/DoughnutChart.js'
 import LineChart from '../../components/LineChart/LineChart.js'
 import { Component } from '../../core/component.js'
-import { getState, subscribe } from '../../core/observer.js'
+import { getState, subscribe, unsubscribeAll } from '../../core/observer.js'
 import { selectedCategoryState } from '../../stores/chartStore.js'
 import { transactionListState } from '../../stores/transactionStore.js'
 import { classifyTransactionDataByDate } from '../../utils/transactionUtil.js'
@@ -12,6 +12,7 @@ export default class ChartPage extends Component {
   constructor() {
     super()
 
+    unsubscribeAll(transactionListState)
     subscribe(transactionListState, this.render.bind(this))
     subscribe(selectedCategoryState, this.render.bind(this))
   }


### PR DESCRIPTION
## 📑 개요

페이지 이동 시, 거래내역 전역 상태 unsubscribe 처리

## 📎 관련 이슈

close #86

## 💬 작업 내용

페이지 이동 시, 이전 페이지의 렌더링 함수가 옵저버에 남아있어 같이 렌더링되는 버그가 있었습니다.

그래서 페이지 이동 시, `transactionListState` 옵저버를 비우고 해당 페이지의 렌더링 함수를 넣어주었습니다.


## 🚧 PR 특이 사항

FIX BUG 🐞