### PR TITLE
Feat/96/transaction optimistic

### DIFF
--- a/src/frontend/api/transactionHistory.js
+++ b/src/frontend/api/transactionHistory.js
@@ -24,6 +24,8 @@ const getCategorySixMonthTrend = async (year, month, category) => {
 
 const createTransactionAPI = async (body) => {
   const { data } = await fetcher.post('/transaction', body)
+
+  return data
 }
 
 const updateTransactionAPI = async (id, body) => {

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -15,7 +15,7 @@ export default class PaymentBar extends Component {
   constructor() {
     super()
 
-    this.setTransaction = setState('transactionListState')
+    this.setTransaction = setState(transactionListState)
   }
 
   initState() {

--- a/src/frontend/components/PaymentBar/PaymentBar.js
+++ b/src/frontend/components/PaymentBar/PaymentBar.js
@@ -8,8 +8,16 @@ import CategoryDropdown from '../CategoryDropdown/CategoryDropdown.js'
 import PaymentDropdown from '../PaymentDropdown/PaymentDropdown.js'
 import { priceToString, todayDate } from '../../utils/stringUtil.js'
 import { createTransactionAPI } from '../../api/transactionHistory.js'
+import { getState, setState } from '../../core/observer.js'
+import { transactionListState } from '../../stores/transactionStore.js'
 
 export default class PaymentBar extends Component {
+  constructor() {
+    super()
+
+    this.setTransaction = setState('transactionListState')
+  }
+
   initState() {
     this.state = {
       paymentDate: todayDate(),
@@ -106,21 +114,41 @@ export default class PaymentBar extends Component {
     )
   }
 
-  submitForm(e) {
+  async submitForm(e) {
     const result = e.target.closest('.submit')
     if (!result) return
 
-    const { paymentDate, category, title, payment_id, price, option } = this.state
+    const { paymentDate, category, title, payment_id, paymentName, price, option } = this.state
     let tmpPrice = Number(price.replace(/,/g, ''))
     tmpPrice = option ? tmpPrice : -tmpPrice
-    const data = {
+
+    const submitData = {
       paymentDate,
       category,
       title,
       payment_id,
       price: tmpPrice,
     }
-    createTransactionAPI(data)
+
+    try {
+      const { insertId } = await createTransactionAPI(submitData)
+      const transactionList = getState(transactionListState)
+      const setData = {
+        category,
+        id: insertId,
+        is_deleted: 0,
+        payment: paymentName,
+        payment_date: paymentDate,
+        payment_id: payment_id,
+        price: tmpPrice,
+        title: title,
+      }
+
+      this.setTransaction([...transactionList, setData])
+      debugger
+    } catch (e) {
+      console.error(e)
+    }
 
     this.setState({
       paymentDate: todayDate(),


### PR DESCRIPTION
## 📑 개요

거래내역 추가 시 낙관적 업데이트 수행

## 📎 관련 이슈

close #96 

## 💬 작업 내용

거래내역 추가 시, 새로고침이나 네트워크 비용 없이 UI적으로 바로 보이게끔, 낙관적 업데이트를 수행했습니다.
거래내역 리스트와 데이터 폼을 맞추기 위해 데이터 처리 작업을 해주었습니다.

## 🖼 스크린샷(추가사항)

거래내역 추가 후, 반환되는 id값과 필요한 데이터를 가공 후 리스트 업데이트 로직
<img width="528" alt="스크린샷 2022-07-29 오전 12 12 50" src="https://user-images.githubusercontent.com/52727782/181573643-7a3c71bb-eb0a-4cd7-8f26-1b67d0ee523b.png">

